### PR TITLE
Refactoring kimpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,12 @@ For exampe:
     FUNCTIONS
         get_compute_argument_name(...)
         get_compute_argument_name(index: int) -> tuple
-        Return(ComputeArgumentName, error)
+        Return computeArgumentName
     ```
 
     shows that the function `get_compute_argument_name` takes an integer
-    `index` as input, and returns a tuple of two outputs: `ComputeArgumentName`
-    and `error`. You can refer to `KIM API` docs for the meaning of the input
-    and outputs.
+    `index` as input, and returns an output: `computeArgumentName`. You can
+    refer to `KIM API` docs for the meaning of the input and outputs.
 
     All the attributes of the module are listed under `DATA`. For example,
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,12 @@ For exampe:
     ```sh
     PACKAGE CONTENTS
         charge_unit
+        collection
+        collection_item_type
+        collections
         compute_argument_name
         ...
+        temperature_unit
         time_unit
     ```
 
@@ -137,17 +141,37 @@ For exampe:
     All the functions are listed under `FUNCTIONS`. For example,
 
     ```sh
-    get_compute_argument_name(...)
-
     FUNCTIONS
-        get_compute_argument_name(...)
-        get_compute_argument_name(index: int) -> tuple
-        Return computeArgumentName
+        get_compute_argument_data_type(...) method of builtins.PyCapsule instance
+            get_compute_argument_data_type(compute_argument_name: kimpy.compute_argument_name.ComputeArgumentName) -> KIM::DataType
+
+
+            Get the data_type of each defined standard compute_argument_name.
+
+            Returns:
+                DataType: data_type
+        get_compute_argument_name(...) method of builtins.PyCapsule instance
+            get_compute_argument_name(index: int) -> kimpy.compute_argument_name.ComputeArgumentName
+
+
+            Get the identity of each defined standard compute_argument_name.
+
+            Returns:
+                ComputeArgumentName: compute_argument_name
+
+        get_number_of_compute_argument_names(...) method of builtins.PyCapsule instance
+            get_number_of_compute_argument_names() -> int
+
+
+            Get the number of standard compute_argument_name's defined by the KIM-API.
+
+            Returns:
+                int: number_of_compute_arguments
     ```
 
     shows that the function `get_compute_argument_name` takes an integer
-    `index` as input, and returns an output: `computeArgumentName`. You can
-    refer to `KIM API` docs for the meaning of the input and outputs.
+    `index` as input, and returns an output: `compute_argument_name`. You can
+    refer to `KIM API` docs for further information on the input and outputs.
 
     All the attributes of the module are listed under `DATA`. For example,
 
@@ -161,7 +185,7 @@ For exampe:
 
 ## Copyright
 
-Copyright (c) 2017-2020, Regents of the University of Minnesota.\
+Copyright (c) 2017-2021, Regents of the University of Minnesota.\
 All Rights Reserved
 
 ## Contributing

--- a/api_compatibility.py
+++ b/api_compatibility.py
@@ -3,6 +3,7 @@
 from os.path import dirname, abspath, join, isfile
 from collections import OrderedDict
 import sys
+
 sys.path.insert(0, abspath('kimpy'))
 
 from err import KimPyError
@@ -33,8 +34,7 @@ def read_compatible_table():
             if not line or line[0] == '#':
                 continue
 
-            kimpy_version, kim_api_target_version, \
-                kim_api_backward_version = line.split()
+            kimpy_version, kim_api_target_version, kim_api_backward_version = line.split()
 
             compatible_table[kimpy_version] = {
                 'target': kim_api_target_version,
@@ -45,7 +45,7 @@ def read_compatible_table():
 
 
 def compare_version(x, y):
-    """"Check the version relation of x and y in the format a.b.c.
+    """Check the version relation of x and y in the format a.b.c.
 
     Return:
         str: the version relation of x and y

--- a/api_compatibility.py
+++ b/api_compatibility.py
@@ -155,27 +155,30 @@ def check_kim_api_compatibility(kimpy_version, kim_api_version):
             cmp_2 = False
 
     if not cmp_1 or not cmp_2:
-        msg1 = 'KIM-API version = "{}" detected, '.format(kim_api_version)
-        msg1 += 'which is incompatible with the current kimpy version = '
-        msg1 += '"{}".\nTry one of the below:\n'.format(kimpy_version)
+        msg0 = "\n\n\n{}\n".format("=" * 80)
 
-        msg2 = '  (1) Update KIM-API. The current kimpy is compatible with '
-        msg2 += 'KIM-API versions "{}" ~ '.format(backward)
-        msg2 += '"{}" (including).\n'.format(target)
+        msg1 = 'KIM-API version = "{}" is detected, '.format(kim_api_version)
+        msg1 += 'which is incompatible with the current\n  kimpy version = '
+        msg1 += '"{}".\n\nTry one of these options:\n\n'.format(kimpy_version)
+
+        msg2 = '  (1) Update KIM-API.\n      The current kimpy is '
+        msg2 += 'compatible with KIM-API versions:\n '
+        msg2 += '     ["{}" - "{}"] (inclusive).\n'.format(backward, target)
 
         if not cmp_1:
-            msg3 = '  (2) Use the latest kimpy. If you are using the latest '
-            msg3 += 'kimpy, it seems there is not a kimpy compatible with '
-            msg3 += 'this KIM-API version "{}" yet.\n'.format(kim_api_version)
-            msg3 += 'Please contact Mingjian Wen (wenxx151@umn.edu) or raise '
-            msg3 += 'an issue on github so we update the kimpy.\n'
+            msg3 = '  (2) Use the latest kimpy.\n      If you are using the '
+            msg3 += 'latest kimpy, which is not compatible '
+            msg3 += 'with this\n      KIM-API version '
+            msg3 += '"{}" yet. Please contact\n      '.format(kim_api_version)
+            msg3 += 'Mingjian Wen (wenxx151@umn.edu)  or\n      '
+            msg3 += 'raise an issue on github so we update the kimpy.\n'
         else:
             compatible_kimpy = suggest_kimpy(kim_api_version, compatible_table)
-            msg3 = '  (2) Switch kimpy version. The detected KIM-API is '
-            msg3 += 'compatible with kimpy version '
+            msg3 = '  (2) Switch kimpy version.\n      The detected KIM-API '
+            msg3 += 'is compatible with kimpy version '
             msg3 += '"{}".\n'.format(compatible_kimpy)
 
-        msg = msg1 + msg2 + msg3
+        msg = msg0 + msg1 + msg2 + msg3
     else:
         msg = None
 

--- a/examples/example_collections.py
+++ b/examples/example_collections.py
@@ -2,9 +2,12 @@ import kimpy
 
 
 def dirs_for_collection(collection, collections):
-    for it in (kimpy.collection_item_type.modelDriver,
-               kimpy.collection_item_type.portableModel,
-               kimpy.collection_item_type.simulatorModel):
+
+    for it in (
+        kimpy.collection_item_type.modelDriver,
+        kimpy.collection_item_type.portableModel,
+        kimpy.collection_item_type.simulatorModel,
+    ):
         try:
             extent = collections.cache_list_of_directory_names(collection, it)
         except RuntimeError:
@@ -25,13 +28,16 @@ def dirs_for_collection(collection, collections):
 
 
 def names_for_collection(collection, collections):
-    for it in (kimpy.collection_item_type.modelDriver,
-               kimpy.collection_item_type.portableModel,
-               kimpy.collection_item_type.simulatorModel):
+
+    for it in (
+        kimpy.collection_item_type.modelDriver,
+        kimpy.collection_item_type.portableModel,
+        kimpy.collection_item_type.simulatorModel,
+    ):
         try:
-            extent = \
-                collections.cache_list_of_item_names_by_collection_and_type(
-                    collection, it)
+            extent = collections.cache_list_of_item_names_by_collection_and_type(
+                collection, it
+            )
         except RuntimeError:
             msg = 'Calling "collections.'
             msg += 'cache_list_of_item_names_by_collection_and_type" failed.'
@@ -52,6 +58,7 @@ def names_for_collection(collection, collections):
 
 
 def example_main():
+
     try:
         collections = kimpy.collections.create()
     except RuntimeError:
@@ -63,9 +70,11 @@ def example_main():
     print('Project: {}'.format(project))
     print('semVer: {}'.format(semver))
 
-    for it in (kimpy.collection_item_type.modelDriver,
-               kimpy.collection_item_type.portableModel,
-               kimpy.collection_item_type.simulatorModel):
+    for it in (
+        kimpy.collection_item_type.modelDriver,
+        kimpy.collection_item_type.portableModel,
+        kimpy.collection_item_type.simulatorModel,
+    ):
         try:
             name = collections.get_environment_variable_name(it)
         except RuntimeError:
@@ -83,21 +92,27 @@ def example_main():
 
     print('config file name: {}'.format(filename))
 
-    for kc in (kimpy.collection.system,
-               kimpy.collection.user,
-               kimpy.collection.environmentVariable,
-               kimpy.collection.currentWorkingDirectory):
+    for kc in (
+        kimpy.collection.system,
+        kimpy.collection.user,
+        kimpy.collection.environmentVariable,
+        kimpy.collection.currentWorkingDirectory,
+    ):
         dirs_for_collection(kc, collections)
 
-    for kc in (kimpy.collection.system,
-               kimpy.collection.user,
-               kimpy.collection.environmentVariable,
-               kimpy.collection.currentWorkingDirectory):
+    for kc in (
+        kimpy.collection.system,
+        kimpy.collection.user,
+        kimpy.collection.environmentVariable,
+        kimpy.collection.currentWorkingDirectory,
+    ):
         names_for_collection(kc, collections)
 
-    for it in (kimpy.collection_item_type.modelDriver,
-               kimpy.collection_item_type.portableModel,
-               kimpy.collection_item_type.simulatorModel):
+    for it in (
+        kimpy.collection_item_type.modelDriver,
+        kimpy.collection_item_type.portableModel,
+        kimpy.collection_item_type.simulatorModel,
+    ):
         try:
             extent = collections.cache_list_of_item_names_by_type(it)
         except RuntimeError:
@@ -118,10 +133,10 @@ def example_main():
             print('    {}'.format(name))
 
     try:
-        filename, collection = \
-            collections.get_item_library_file_name_and_collection(
-                kimpy.collection_item_type.simulatorModel,
-                'Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu',)
+        filename, collection = collections.get_item_library_file_name_and_collection(
+            kimpy.collection_item_type.simulatorModel,
+            'Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu',
+        )
     except RuntimeError:
         msg = 'Calling "collections.'
         msg += 'get_item_library_file_name_and_collection" failed.'
@@ -135,7 +150,8 @@ def example_main():
     try:
         extent = collections.cache_list_of_item_metadata_files(
             kimpy.collection_item_type.simulatorModel,
-            "Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu")
+            "Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu",
+        )
     except RuntimeError:
         msg = 'Calling "collections.'
         msg += 'cache_list_of_item_metadata_files" failed.'
@@ -143,8 +159,13 @@ def example_main():
 
     for i in range(extent):
         try:
-            file_name, file_length, file_raw_data, \
-                avail_as_str, file_str = collections.get_item_metadata_file(i)
+            (
+                file_name,
+                file_length,
+                file_raw_data,
+                avail_as_str,
+                file_str,
+            ) = collections.get_item_metadata_file(i)
         except RuntimeError:
             msg = 'Calling "collections.get_item_metadata_file" '
             msg += 'for index = {} failed.'.format(i)

--- a/examples/example_collections.py
+++ b/examples/example_collections.py
@@ -1,123 +1,160 @@
 import kimpy
-from kimpy import charge_unit, check_error
 
 
-def dirs_for_collection(collection, col):
-    for it in [
-        kimpy.collection_item_type.modelDriver,
-        kimpy.collection_item_type.portableModel,
-        kimpy.collection_item_type.simulatorModel,
-    ]:
-        extent, error = col.cache_list_of_directory_names(collection, it)
-        check_error(error, 'cache_list_of_directory_names')
-        print(str(collection), ':', str(it), ':')
+def dirs_for_collection(collection, collections):
+    for it in (kimpy.collection_item_type.modelDriver,
+               kimpy.collection_item_type.portableModel,
+               kimpy.collection_item_type.simulatorModel):
+        try:
+            extent = collections.cache_list_of_directory_names(collection, it)
+        except RuntimeError:
+            msg = 'Calling "collections.cache_list_of_directory_names" failed.'
+            raise kimpy.KimPyError(msg)
+
+        print('{}:{}:'.format(str(collection), str(it)))
 
         for i in range(extent):
-            name, error = col.get_directory_name(i)
-            check_error(error, 'get_directory_name')
+            try:
+                name = collections.get_directory_name(i)
+            except RuntimeError:
+                msg = 'Calling "collections.get_directory_name" for index = '
+                msg += '{} failed.'.format(i)
+                raise kimpy.KimPyError(msg)
+
             print('    ', name)
 
 
-def names_for_collection(collection, col):
-    for it in [
-        kimpy.collection_item_type.modelDriver,
-        kimpy.collection_item_type.portableModel,
-        kimpy.collection_item_type.simulatorModel,
-    ]:
-        extent, error = \
-            col.cache_list_of_item_names_by_collection_and_type(collection, it)
-        check_error(error, 'cache_list_of_directory_names')
-        print(str(collection), ':', str(it), ':')
+def names_for_collection(collection, collections):
+    for it in (kimpy.collection_item_type.modelDriver,
+               kimpy.collection_item_type.portableModel,
+               kimpy.collection_item_type.simulatorModel):
+        try:
+            extent = \
+                collections.cache_list_of_item_names_by_collection_and_type(
+                    collection, it)
+        except RuntimeError:
+            msg = 'Calling "collections.'
+            msg += 'cache_list_of_item_names_by_collection_and_type" failed.'
+            raise kimpy.KimPyError(msg)
+
+        print('{}:{}:'.format(str(collection), str(it)))
 
         for i in range(extent):
-            name, error = col.get_item_name_by_collection_and_type(i)
-            check_error(error, 'get_item_name_by_collection_and_type')
+            try:
+                name = collections.get_item_name_by_collection_and_type(i)
+            except RuntimeError:
+                msg = 'Calling "collections.'
+                msg += 'get_item_name_by_collection_and_type" for index = '
+                msg += '{} failed.'.format(i)
+                raise kimpy.KimPyError(msg)
+
             print('    ', name)
 
 
 def example_main():
-    col, error = kimpy.collections.create()
-    check_error(error, 'collections.create')
+    try:
+        collections = kimpy.collections.create()
+    except RuntimeError:
+        msg = 'Calling "kimpy.collections.create" failed.'
+        raise kimpy.KimPyError(msg)
 
-    project, semver = col.get_project_name_and_sem_ver()
-    print('Project:', project)
-    print('semVer:', semver)
+    project, semver = collections.get_project_name_and_sem_ver()
 
-    for it in [
-        kimpy.collection_item_type.modelDriver,
-        kimpy.collection_item_type.portableModel,
-        kimpy.collection_item_type.simulatorModel,
-    ]:
-        name, error = col.get_environment_variable_name(it)
-        check_error(error, 'get_environment_variable_name')
-        print(str(it), ' env name:', name)
+    print('Project: {}'.format(project))
+    print('semVer: {}'.format(semver))
 
-    name, value = col.get_configuration_file_environment_variable()
-    print('config file env name:', name)
-    print('config file env value:', value)
+    for it in (kimpy.collection_item_type.modelDriver,
+               kimpy.collection_item_type.portableModel,
+               kimpy.collection_item_type.simulatorModel):
+        try:
+            name = collections.get_environment_variable_name(it)
+        except RuntimeError:
+            msg = 'Calling "collections.get_environment_variable_name" failed.'
+            raise kimpy.KimPyError(msg)
 
-    filename = col.get_configuration_file_name()
-    print('config file name:', filename)
+        print('{} env name:{}'.format(str(it), name))
 
-    for kc in [
-        kimpy.collection.system,
-        kimpy.collection.user,
-        kimpy.collection.environmentVariable,
-        kimpy.collection.currentWorkingDirectory,
-    ]:
-        dirs_for_collection(kc, col)
+    name, value = collections.get_configuration_file_environment_variable()
 
-    for kc in [
-        kimpy.collection.system,
-        kimpy.collection.user,
-        kimpy.collection.environmentVariable,
-        kimpy.collection.currentWorkingDirectory,
-    ]:
-        names_for_collection(kc, col)
+    print('config file env name: {}'.format(name))
+    print('config file env value: {}'.format(value))
 
-    for it in [
-        kimpy.collection_item_type.modelDriver,
-        kimpy.collection_item_type.portableModel,
-        kimpy.collection_item_type.simulatorModel,
-    ]:
-        extent, error = col.cache_list_of_item_names_by_type(it)
-        check_error(error, 'cache_list_of_item_names_by_type')
-        print(str(it), ':')
+    filename = collections.get_configuration_file_name()
+
+    print('config file name: {}'.format(filename))
+
+    for kc in (kimpy.collection.system,
+               kimpy.collection.user,
+               kimpy.collection.environmentVariable,
+               kimpy.collection.currentWorkingDirectory):
+        dirs_for_collection(kc, collections)
+
+    for kc in (kimpy.collection.system,
+               kimpy.collection.user,
+               kimpy.collection.environmentVariable,
+               kimpy.collection.currentWorkingDirectory):
+        names_for_collection(kc, collections)
+
+    for it in (kimpy.collection_item_type.modelDriver,
+               kimpy.collection_item_type.portableModel,
+               kimpy.collection_item_type.simulatorModel):
+        try:
+            extent = collections.cache_list_of_item_names_by_type(it)
+        except RuntimeError:
+            msg = 'Calling "collections.'
+            msg += 'cache_list_of_item_names_by_type" failed.'
+            raise kimpy.KimPyError(msg)
+
+        print('{}:'.format(str(it)))
 
         for i in range(extent):
-            name, error = col.get_item_name_by_type(i)
-            check_error(error, 'get_item_name_by_type')
-            print('    ', name)
+            try:
+                name = collections.get_item_name_by_type(i)
+            except RuntimeError:
+                msg = 'Calling "collections.get_item_name_by_type" '
+                msg += 'for index = {} failed.'.format(i)
+                raise kimpy.KimPyError(msg)
 
-    filename, collection, error = \
-        col.get_item_library_file_name_and_collection(
-            kimpy.collection_item_type.simulatorModel,
-            'Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu',)
+            print('    {}'.format(name))
 
-    check_error(error, 'get_item_library_file_name_and_collection')
+    try:
+        filename, collection = \
+            collections.get_item_library_file_name_and_collection(
+                kimpy.collection_item_type.simulatorModel,
+                'Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu',)
+    except RuntimeError:
+        msg = 'Calling "collections.'
+        msg += 'get_item_library_file_name_and_collection" failed.'
+        raise kimpy.KimPyError(msg)
 
     msg = 'Simulator Model Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu '
     msg += 'has library name "{}" and is part of the '.format(filename)
     msg += '"{}" collection'.format(str(collection))
     print(msg)
 
-    extent, error = col.cache_list_of_item_metadata_files(
-        kimpy.collection_item_type.simulatorModel,
-        "Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu",
-    )
-    check_error(error, 'cache_list_of_item_metadata_files')
+    try:
+        extent = collections.cache_list_of_item_metadata_files(
+            kimpy.collection_item_type.simulatorModel,
+            "Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu")
+    except RuntimeError:
+        msg = 'Calling "collections.'
+        msg += 'cache_list_of_item_metadata_files" failed.'
+        raise kimpy.KimPyError(msg)
 
     for i in range(extent):
-        file_name, file_length, file_raw_data, \
-            avail_as_str, file_str, error = col.get_item_metadata_file(i)
+        try:
+            file_name, file_length, file_raw_data, \
+                avail_as_str, file_str = collections.get_item_metadata_file(i)
+        except RuntimeError:
+            msg = 'Calling "collections.get_item_metadata_file" '
+            msg += 'for index = {} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
 
-        check_error(error, 'get_item_metadata_file')
         msg = 'Metadata file {} ({}) '.format(i, file_name)
         msg += 'is of length {}'.format(file_length)
+
         print(msg)
         print(file_str)
-
-    kimpy.collections.destroy(col)
 
 
 if __name__ == '__main__':

--- a/examples/example_simulator_model.py
+++ b/examples/example_simulator_model.py
@@ -3,6 +3,7 @@ import kimpy
 
 
 def example_main():
+
     modelname = 'Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu'
 
     try:

--- a/examples/example_simulator_model.py
+++ b/examples/example_simulator_model.py
@@ -1,37 +1,63 @@
-import kimpy
-from kimpy import check_error, report_error
 from os.path import join
+import kimpy
 
 
 def example_main():
     modelname = 'Sim_LAMMPS_LJcut_AkersonElliott_Alchemy_PbAu'
-    sm, error = kimpy.simulator_model.create(modelname)
-    check_error(error, 'simulator_model.create')
+
+    try:
+        sm = kimpy.simulator_model.create(modelname)
+    except RuntimeError:
+        msg = 'Calling "kimpy.simulator_model.create" failed.'
+        raise kimpy.KimPyError(msg)
 
     name, version = sm.get_simulator_name_and_version()
-    print('Simulator name:', name)
-    print('Simulator version:', version)
+
+    print('Simulator name: {}'.format(name))
+    print('Simulator version: {}'.format(version))
 
     extent = sm.get_number_of_supported_species()
     print('Simulator supports {} species.'.format(extent))
+
     for i in range(extent):
-        species, error = sm.get_supported_species(i)
-        check_error(error, 'get_supported_species')
+        try:
+            species = sm.get_supported_species(i)
+        except RuntimeError:
+            msg = 'Calling "sm.get_supported_species" for '
+            msg += 'index = {} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
+
         print('{}  {}'.format(i, species))
 
-    error = sm.add_template_map('atom-type-sym-list', 'Pb Pb Au Pb')
-    check_error(error, 'add_template_map')
+    try:
+        sm.add_template_map('atom-type-sym-list', 'Pb Pb Au Pb')
+    except RuntimeError:
+        raise kimpy.KimPyError('Calling "sm.add_template_map" failed.')
+
     sm.close_template_map()
+
     number_fields = sm.get_number_of_simulator_fields()
     print('Simulator model has {} fields.'.format(number_fields))
 
     for i in range(number_fields):
-        extent, field_name, error = sm.get_simulator_field_metadata(i)
-        check_error(error, 'get_simulator_field_metadata')
+        try:
+            extent, field_name = sm.get_simulator_field_metadata(i)
+        except RuntimeError:
+            msg = 'Calling "sm.get_simulator_field_metadata" for '
+            msg += 'fieldIndex = {} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
+
         print('Field {} is {} and has lines: {}'.format(i, field_name, extent))
+
         for j in range(extent):
-            field_line, error = sm.get_simulator_field_line(i, j)
-            check_error(error, 'get_simulator_field_line')
+            try:
+                field_line = sm.get_simulator_field_line(i, j)
+            except RuntimeError:
+                msg = 'Calling "sm.get_simulator_field_line" for '
+                msg += 'fieldIndex = {} & lineIndex = '.format(i)
+                msg += '{} failed.'.format(j)
+                raise kimpy.KimPyError(msg)
+
             print('    ', field_line)
 
     dirname = sm.get_parameter_file_directory_name()
@@ -39,21 +65,27 @@ def example_main():
 
     specname = sm.get_specification_file_name()
     print('Simulator model specification file name is:', specname)
+
     fname = join(dirname, specname)
     with open(fname, 'r') as f:
         print(f.read())
 
     num_param_files = sm.get_number_of_parameter_files()
     print('Simulator model has {} parameter files.'.format(num_param_files))
+
     for i in range(num_param_files):
-        paramname, error = sm.get_parameter_file_name(i)
-        check_error(error, 'get_parameter_file_name')
+        try:
+            paramname = sm.get_parameter_file_name(i)
+        except RuntimeError:
+            msg = 'Calling "sm.get_parameter_file_name" for '
+            msg += 'index = {} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
+
         print('Parameter file {} has name: {}'.format(i, paramname))
+
         fname = join(dirname, paramname)
         with open(fname, 'r') as f:
             print(f.read())
-
-    kimpy.simulator_model.destroy(sm)
 
 
 if __name__ == '__main__':

--- a/kimpy/KIM_Collections_bind.cpp
+++ b/kimpy/KIM_Collections_bind.cpp
@@ -55,7 +55,7 @@ PYBIND11_MODULE(collections, module)
        a specific name.
 
        Returns:
-           collection_item_type
+           CollectionItemType: collection_item_type
        )pbdoc",
        py::arg("item_name"))
     .def("get_item_library_file_name_and_collection",
@@ -82,7 +82,7 @@ PYBIND11_MODULE(collections, module)
        Get the item's library file name and its KIM::Collection.
 
        Returns:
-           str, collection: file_name, collection
+           str, Collection: file_name, collection
        )pbdoc",
        py::arg("item_type"),
        py::arg("item_name"))
@@ -138,7 +138,7 @@ PYBIND11_MODULE(collections, module)
        Get the name and content of one of an item's metadata files.
 
        Returns:
-           str, int, str, bool, str: file_name, file_length, file_raw_data,
+           str, int, str, int, str: file_name, file_length, file_raw_data,
                 available_as_string, file_string
        )pbdoc",
        py::arg("index"))
@@ -296,7 +296,7 @@ PYBIND11_MODULE(collections, module)
        Get the name and content of one of an item's metadata files.
 
        Returns:
-           str, int, str, bool, int: file_name, file_length, file_raw_data,
+           str, int, str, int, int: file_name, file_length, file_raw_data,
                 available_as_string, file_string
        )pbdoc",
        py::arg("index"))
@@ -432,6 +432,6 @@ PYBIND11_MODULE(collections, module)
        Create a new KIM-API collections object.
 
        Returns:
-           collections: collections
+           Collections: collections
        )pbdoc");
 }

--- a/kimpy/KIM_Collections_bind.cpp
+++ b/kimpy/KIM_Collections_bind.cpp
@@ -41,19 +41,23 @@ PYBIND11_MODULE(collections, module)
     }))
     .def("get_item_type",
          [](Collections &self, std::string const &item_name) {
-      CollectionItemType item_type;
+      CollectionItemType collection_item_type;
 
-      int error = self.GetItemType(item_name, &item_type);
+      int error = self.GetItemType(item_name, &collection_item_type);
       if (error == 1) {
         throw std::runtime_error(
           "An item with the specificed name cannot be found!");
       }
 
-      return item_type;
-    }, "Get the collection_item_type of the item in the KIM-API "
-       "collections with a specific name.",
-       py::arg("item_name"),
-       "Return item_type")
+      return collection_item_type;
+    }, R"pbdoc(
+       Get the collection_item_type of the item in the KIM-API collections with
+       a specific name.
+
+       Returns:
+           collection_item_type
+       )pbdoc",
+       py::arg("item_name"))
     .def("get_item_library_file_name_and_collection",
          [](Collections &self,
             CollectionItemType const &item_type,
@@ -74,10 +78,14 @@ PYBIND11_MODULE(collections, module)
       re[0] = *file_name;
       re[1] = collection;
       return re;
-    }, "Get the item's library file name and its KIM::Collection.",
+    }, R"pbdoc(
+       Get the item's library file name and its KIM::Collection.
+
+       Returns:
+           str, collection: file_name, collection
+       )pbdoc",
        py::arg("item_type"),
-       py::arg("item_name"),
-       "Return(file_name, collection)")
+       py::arg("item_name"))
     .def("cache_list_of_item_metadata_files",
          [](Collections &self,
             CollectionItemType const &item_type,
@@ -93,10 +101,14 @@ PYBIND11_MODULE(collections, module)
       }
 
       return extent;
-    }, "Cache a list of an item's metadata files.",
+    }, R"pbdoc(
+       Cache a list of an item's metadata files.
+
+       Returns:
+           int: extent
+       )pbdoc",
        py::arg("item_type"),
-       py::arg("item_name"),
-       "Return extent")
+       py::arg("item_name"))
     .def("get_item_metadata_file",
          [](Collections &self, int const index) {
       std::string const *file_name;
@@ -122,10 +134,14 @@ PYBIND11_MODULE(collections, module)
       re[3] = available_as_string;
       re[4] = *file_string;
       return re;
-    }, "Get the name and content of one of an item's metadata files.",
-       py::arg("index"),
-       "Return(file_name, file_length, file_raw_data, "
-       "available_as_string, file_string)")
+    }, R"pbdoc(
+       Get the name and content of one of an item's metadata files.
+
+       Returns:
+           str, int, str, bool, str: file_name, file_length, file_raw_data,
+                available_as_string, file_string
+       )pbdoc",
+       py::arg("index"))
     .def("cache_list_of_item_names_by_type",
          [](Collections &self, CollectionItemType const &item_type) {
       int extent;
@@ -136,10 +152,14 @@ PYBIND11_MODULE(collections, module)
       }
 
       return extent;
-    }, "Cache a list of all item names of a specific type in the KIM-API "
-       "collections.",
-       py::arg("item_type"),
-       "Return extent")
+    }, R"pbdoc(
+       Cache a list of all item names of a specific type in the KIM-API
+       collections.
+
+       Returns:
+           int: extent
+       )pbdoc",
+       py::arg("item_type"))
     .def("get_item_name_by_type", [](Collections &self, int const index) {
       std::string const *item_name;
 
@@ -149,9 +169,13 @@ PYBIND11_MODULE(collections, module)
       }
 
       return *item_name;
-    }, "Get the name of an item from the cached list.",
-       py::arg("index"),
-       "Return item_name")
+    }, R"pbdoc(
+       Get the name of an item from the cached list.
+
+       Returns:
+           str: item_name
+       )pbdoc",
+       py::arg("index"))
     .def("cache_list_of_item_names_by_collection_and_type",
          [](Collections &self,
             Collection const &collection,
@@ -165,11 +189,15 @@ PYBIND11_MODULE(collections, module)
       }
 
       return extent;
-    }, "Cache a list of all item names of a specific type in a specific "
-       "collection.",
+    }, R"pbdoc(
+       Cache a list of all item names of a specific type in a specific
+       collection.
+
+       Returns:
+           int: extent
+       )pbdoc",
        py::arg("collection"),
-       py::arg("item_type"),
-       "Return extent")
+       py::arg("item_type"))
     .def("get_item_name_by_collection_and_type",
          [](Collections &self, int const index) {
       std::string const *item_name;
@@ -180,9 +208,13 @@ PYBIND11_MODULE(collections, module)
       }
 
       return *item_name;
-    }, "Get the name of an item from the cached list.",
-       py::arg("index"),
-       "Return item_name")
+    }, R"pbdoc(
+       Get the name of an item from the cached list.
+
+       Returns:
+           str: item_name
+       )pbdoc",
+       py::arg("index"))
     .def("get_item_library_file_name_by_collection_and_type",
          [](Collections &self,
             Collection const &collection,
@@ -200,11 +232,15 @@ PYBIND11_MODULE(collections, module)
       }
 
       return *file_name;
-    }, "Get the item's library file name.",
+    }, R"pbdoc(
+       Get the item's library file name.
+
+       Returns:
+           str: file_name
+       )pbdoc",
        py::arg("collection"),
        py::arg("item_type"),
-       py::arg("item_name"),
-       "Return file_name")
+       py::arg("item_name"))
     .def("cache_list_of_item_metadata_files_by_collection_and_type",
          [](Collections &self,
             Collection const &collection,
@@ -221,11 +257,15 @@ PYBIND11_MODULE(collections, module)
       }
 
       return extent;
-    }, "Cache a list of an item's metadata files.",
+    }, R"pbdoc(
+       Cache a list of an item's metadata files.
+
+       Returns:
+           int: extent
+       )pbdoc",
        py::arg("collection"),
        py::arg("item_type"),
-       py::arg("item_name"),
-       "Return extent")
+       py::arg("item_name"))
     .def("get_item_metadata_file_by_collection_and_type",
          [](Collections &self, int const index) {
       std::string const *file_name;
@@ -252,10 +292,14 @@ PYBIND11_MODULE(collections, module)
       re[3] = available_as_string;
       re[4] = *file_string;
       return re;
-    }, "Get the name and content of one of an item's metadata files.",
-       py::arg("index"),
-       "Return(file_name, file_length, file_raw_data, "
-       "available_as_string, file_string)")
+    }, R"pbdoc(
+       Get the name and content of one of an item's metadata files.
+
+       Returns:
+           str, int, str, bool, int: file_name, file_length, file_raw_data,
+                available_as_string, file_string
+       )pbdoc",
+       py::arg("index"))
     .def("get_project_name_and_sem_ver", [](Collections &self) {
       std::string const *project_name;
       std::string const *sem_ver;
@@ -266,8 +310,12 @@ PYBIND11_MODULE(collections, module)
       re[0] = *project_name;
       re[1] = *sem_ver;
       return re;
-    }, "Get the KIM-API project name and full Semantic Version string.",
-       "Return(project_name, sem_ver)")
+    }, R"pbdoc(
+       Get the KIM-API project name and full Semantic Version string.
+
+       Returns:
+           str, str: project_name, sem_ver
+       )pbdoc")
     .def("get_environment_variable_name",
          [](Collections &self, CollectionItemType const &item_type) {
       std::string const *name;
@@ -278,10 +326,14 @@ PYBIND11_MODULE(collections, module)
       }
 
       return *name;
-    }, "Get the names of environment variables that store configuration "
-       "settings for the KIM::COLLECTION::environmentVariable collection.",
-       py::arg("item_type"),
-       "Return name")
+    }, R"pbdoc(
+       Get the names of environment variables that store configuration
+       settings for the KIM::COLLECTION::environmentVariable collection.
+
+       Returns:
+           str: name
+       )pbdoc",
+       py::arg("item_type"))
     .def("get_configuration_file_environment_variable",
          [](Collections &self) {
       std::string const *name;
@@ -293,18 +345,26 @@ PYBIND11_MODULE(collections, module)
       re[0] = *name;
       re[1] = *value;
       return re;
-    }, "Get the name and value of the environment variable that stores the "
-       "name of the KIM-API user configuration file.",
-       "Return(name, value)")
+    }, R"pbdoc(
+       Get the name and value of the environment variable that stores the
+       name of the KIM-API user configuration file.
+
+       Returns:
+           str, str: name, value
+       )pbdoc")
     .def("get_configuration_file_name", [](Collections &self) {
       std::string const *file_name;
 
       self.GetConfigurationFileName(&file_name);
 
       return *file_name;
-    }, "Get the absolute file and path name of the KIM-API user "
-       "configuration file.",
-       "Return file_name")
+    }, R"pbdoc(
+       Get the absolute file and path name of the KIM-API user configuration
+       file.
+
+       Returns:
+           str: file_name
+       )pbdoc")
     .def("cache_list_of_directory_names",
          [](Collections &self,
             Collection const &collection,
@@ -320,11 +380,15 @@ PYBIND11_MODULE(collections, module)
       }
 
       return extent;
-    }, "Cache a list of directory names where a specific KIM-API "
-       "collection stores library files for a specific item type.",
+    }, R"pbdoc(
+       Cache a list of directory names where a specific KIM-API
+       collection stores library files for a specific item type.
+
+       Returns:
+           int: extent
+       )pbdoc",
        py::arg("collection"),
-       py::arg("item_type"),
-       "Return extent")
+       py::arg("item_type"))
     .def("get_directory_name", [](Collections &self, int const index) {
       std::string const *directory_name;
 
@@ -334,9 +398,13 @@ PYBIND11_MODULE(collections, module)
       }
 
       return *directory_name;
-    }, "Get the name of a directory from the cached list.",
-       py::arg("index"),
-       "Return directory_name")
+    }, R"pbdoc(
+       Get the name of a directory from the cached list.
+
+       Returns:
+           str: directory_name
+       )pbdoc",
+       py::arg("index"))
     .def("set_log_id", &Collections::SetLogID,
          "Set the identity of the Log object associated with the "
          "collections object.",
@@ -360,6 +428,10 @@ PYBIND11_MODULE(collections, module)
 
     return std::unique_ptr<Collections, PyCollectionsDestroy>(
       std::move(collections));
-  }, "Create a new KIM-API collections object.",
-     "Return collections");
+  }, R"pbdoc(
+       Create a new KIM-API collections object.
+
+       Returns:
+           collections: collections
+       )pbdoc");
 }

--- a/kimpy/KIM_Collections_bind.cpp
+++ b/kimpy/KIM_Collections_bind.cpp
@@ -10,6 +10,11 @@
 namespace py = pybind11;
 using namespace KIM;
 
+struct PyCollectionsDestroy {
+  void operator()(Collections *collections) const {
+    Collections::Destroy(&collections);
+  }
+};
 
 PYBIND11_MODULE(collections, module)
 {
@@ -23,8 +28,8 @@ PYBIND11_MODULE(collections, module)
   // destroy function from the C++ side to avoid memory leaks. For more info,
   // see http://pybind11.readthedocs.io/en/stable/advanced/classes.html
 
-  py::class_<Collections, std::unique_ptr<Collections, py::nodelete> > cl(
-      module, "Collections");
+  py::class_<Collections, std::unique_ptr<Collections, PyCollectionsDestroy>>
+    cl(module, "Collections");
 
   // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([](py::array_t<int> error) {

--- a/kimpy/KIM_Collections_bind.cpp
+++ b/kimpy/KIM_Collections_bind.cpp
@@ -5,355 +5,361 @@
 #include <string>
 
 #include "KIM_SimulatorHeaders.hpp"
-#include "sim_buffer.h"
 
 namespace py = pybind11;
 using namespace KIM;
 
+
+namespace{
 struct PyCollectionsDestroy {
   void operator()(Collections *collections) const {
     Collections::Destroy(&collections);
   }
 };
+} // namespace
+
 
 PYBIND11_MODULE(collections, module)
 {
   module.doc() = "Python binding to KIM_Collections.hpp";
 
-  // C++ class constructor and destructor are private, which can not be wrapped
-  // directly.
-  // So we need to call the C++ class factory function in py::init, and use
-  // `py::nodelete` to avoid calling the destructor when python instance is
-  // destroyed. It is crucial that the instance is deallocated by calling the
-  // destroy function from the C++ side to avoid memory leaks. For more info,
-  // see http://pybind11.readthedocs.io/en/stable/advanced/classes.html
-
   py::class_<Collections, std::unique_ptr<Collections, PyCollectionsDestroy>>
     cl(module, "Collections");
 
   // python constructor needs to return a pointer to the C++ instance
-  cl.def(py::init([](py::array_t<int> error) {
-      Collections * co;
-      int * e = error.mutable_data(0);
-      e[0] = Collections::Create(&co);
-      return co;
+  cl.def(py::init([]() {
+      Collections *collections;
+
+      int error = Collections::Create(&collections);
+      if (error == 1) {
+        throw std::runtime_error(
+          "Unable to create a new KIM-API collections object!");
+      }
+
+      return std::unique_ptr<Collections, PyCollectionsDestroy>(
+        std::move(collections));
     }))
+    .def("get_item_type",
+         [](Collections &self, std::string const &item_name) {
+      CollectionItemType item_type;
 
-      .def(
-          "get_item_type",
-          [](Collections & self, std::string const & itemName) {
-            CollectionItemType itemType;
-            int error = self.GetItemType(itemName, &itemType);
+      int error = self.GetItemType(item_name, &item_type);
+      if (error == 1) {
+        throw std::runtime_error(
+          "An item with the specificed name cannot be found!");
+      }
 
-            py::tuple re(2);
-            re[0] = itemType;
-            re[1] = error;
-            return re;
-          },
-          py::arg("itemName"),
-          "Return(itemType, error)")
+      return item_type;
+    }, "Get the collection_item_type of the item in the KIM-API "
+       "collections with a specific name.",
+       py::arg("item_name"),
+       "Return item_type")
+    .def("get_item_library_file_name_and_collection",
+         [](Collections &self,
+            CollectionItemType const &item_type,
+            std::string const &item_name) {
+      std::string const *file_name;
 
-      .def(
-          "get_item_library_file_name_and_collection",
-          [](Collections & self,
-             CollectionItemType const itemType,
-             std::string const & itemName) {
-            std::string const * fileName;
-            Collection collection;
-            int error = self.GetItemLibraryFileNameAndCollection(
-                itemType, itemName, &fileName, &collection);
+      Collection collection;
 
-            py::tuple re(3);
-            re[0] = *fileName;
-            re[1] = collection;
-            re[2] = error;
-            return re;
-          },
-          py::arg("itemType"),
-          py::arg("itemName"),
-          "Return(fileName, collection, error)")
+      int error = self.GetItemLibraryFileNameAndCollection(
+        item_type, item_name, &file_name, &collection);
+      if (error == 1) {
+        throw std::runtime_error(
+          "item_type is unknown!  or\nan item with the specified type "
+          "and name cannot be found!");
+      }
 
-      .def(
-          "cache_list_of_item_metadata_files",
-          [](Collections & self,
-             CollectionItemType const itemType,
-             std::string const & itemName) {
-            int extent;
-            int error = self.CacheListOfItemMetadataFiles(
-                itemType, itemName, &extent);
+      py::tuple re(2);
+      re[0] = *file_name;
+      re[1] = collection;
+      return re;
+    }, "Get the item's library file name and its KIM::Collection.",
+       py::arg("item_type"),
+       py::arg("item_name"),
+       "Return(file_name, collection)")
+    .def("cache_list_of_item_metadata_files",
+         [](Collections &self,
+            CollectionItemType const &item_type,
+            std::string const &item_name) {
+      int extent;
 
-            py::tuple re(2);
-            re[0] = extent;
-            re[1] = error;
-            return re;
-          },
-          py::arg("itemType"),
-          py::arg("itemName"),
-          "Return(extent, error)")
+      int error = self.CacheListOfItemMetadataFiles(
+        item_type, item_name, &extent);
+      if (error == 1) {
+        throw std::runtime_error(
+          "item_type is unknown!  or\nthe list is not successfully cached "
+          "for some reason!");
+      }
 
-      .def(
-          "get_item_metadata_file",
-          [](Collections & self, int const index) {
-            std::string const * fileName;
-            unsigned int fileLength;
-            unsigned char const * fileRawData;
-            int availableAsString;
-            std::string const * fileString;
-            int error = self.GetItemMetadataFile(index,
-                                                 &fileName,
-                                                 &fileLength,
-                                                 &fileRawData,
-                                                 &availableAsString,
-                                                 &fileString);
+      return extent;
+    }, "Cache a list of an item's metadata files.",
+       py::arg("item_type"),
+       py::arg("item_name"),
+       "Return extent")
+    .def("get_item_metadata_file",
+         [](Collections &self, int const index) {
+      std::string const *file_name;
+      unsigned int file_length;
+      unsigned char const *file_raw_data;
+      int available_as_string;
+      std::string const *file_string;
 
-            py::tuple re(6);
-            re[0] = *fileName;
-            re[1] = fileLength;
-            re[2] = fileRawData;
-            re[3] = availableAsString;
-            re[4] = *fileString;
-            re[5] = error;
-            return re;
-          },
-          py::arg("index"),
-          "Return(fileName, fileLength, fileRawData, availableAsString, "
-          "fileString, error)")
+      int error = self.GetItemMetadataFile(index,
+                                           &file_name,
+                                           &file_length,
+                                           &file_raw_data,
+                                           &available_as_string,
+                                           &file_string);
+      if (error == 1) {
+        throw std::runtime_error("index is invalid!");
+      }
 
-      .def(
-          "cache_list_of_item_names_by_type",
-          [](Collections & self, CollectionItemType const itemType) {
-            int extent;
-            int error = self.CacheListOfItemNamesByType(itemType, &extent);
+      py::tuple re(5);
+      re[0] = *file_name;
+      re[1] = file_length;
+      re[2] = file_raw_data;
+      re[3] = available_as_string;
+      re[4] = *file_string;
+      return re;
+    }, "Get the name and content of one of an item's metadata files.",
+       py::arg("index"),
+       "Return(file_name, file_length, file_raw_data, "
+       "available_as_string, file_string)")
+    .def("cache_list_of_item_names_by_type",
+         [](Collections &self, CollectionItemType const &item_type) {
+      int extent;
 
-            py::tuple re(2);
-            re[0] = extent;
-            re[1] = error;
-            return re;
-          },
-          py::arg("itemType"),
-          "Return(extent, error)")
+      int error = self.CacheListOfItemNamesByType(item_type, &extent);
+      if (error == 1) {
+        throw std::runtime_error("item_type is unknown!");
+      }
 
-      .def(
-          "get_item_name_by_type",
-          [](Collections & self, int const index) {
-            std::string const * itemName;
-            int error = self.GetItemNameByType(index, &itemName);
+      return extent;
+    }, "Cache a list of all item names of a specific type in the KIM-API "
+       "collections.",
+       py::arg("item_type"),
+       "Return extent")
+    .def("get_item_name_by_type", [](Collections &self, int const index) {
+      std::string const *item_name;
 
-            py::tuple re(2);
-            re[0] = *itemName;
-            re[1] = error;
-            return re;
-          },
-          py::arg("index"),
-          "Return(itemName, error)")
+      int error = self.GetItemNameByType(index, &item_name);
+      if (error == 1) {
+        throw std::runtime_error("index is invalid!");
+      }
 
-      .def(
-          "cache_list_of_item_names_by_collection_and_type",
-          [](Collections & self,
-             Collection const collection,
-             CollectionItemType const itemType) {
-            int extent;
-            int error = self.CacheListOfItemNamesByCollectionAndType(
-                collection, itemType, &extent);
+      return *item_name;
+    }, "Get the name of an item from the cached list.",
+       py::arg("index"),
+       "Return item_name")
+    .def("cache_list_of_item_names_by_collection_and_type",
+         [](Collections &self,
+            Collection const &collection,
+            CollectionItemType const &item_type) {
+      int extent;
 
-            py::tuple re(2);
-            re[0] = extent;
-            re[1] = error;
-            return re;
-          },
-          py::arg("collection"),
-          py::arg("itemType"),
-          "Return(extent, error)")
+      int error = self.CacheListOfItemNamesByCollectionAndType(
+        collection, item_type, &extent);
+      if (error == 1) {
+        throw std::runtime_error("collection or item_type are unknown!");
+      }
 
-      .def(
-          "get_item_name_by_collection_and_type",
-          [](Collections & self, int const index) {
-            std::string const * itemName;
-            int error = self.GetItemNameByCollectionAndType(index, &itemName);
+      return extent;
+    }, "Cache a list of all item names of a specific type in a specific "
+       "collection.",
+       py::arg("collection"),
+       py::arg("item_type"),
+       "Return extent")
+    .def("get_item_name_by_collection_and_type",
+         [](Collections &self, int const index) {
+      std::string const *item_name;
 
-            py::tuple re(2);
-            re[0] = *itemName;
-            re[1] = error;
-            return re;
-          },
-          py::arg("index"),
-          "Return(itemName, error)")
+      int error = self.GetItemNameByCollectionAndType(index, &item_name);
+      if (error == 1) {
+        throw std::runtime_error("index is invalid!");
+      }
 
-      .def(
-          "get_item_library_file_name_by_collection_and_type",
-          [](Collections & self,
-             Collection const collection,
-             CollectionItemType const itemType,
-             std::string const & itemName) {
-            std::string const * fileName;
-            int error = self.GetItemLibraryFileNameByCollectionAndType(
-                collection, itemType, itemName, &fileName);
+      return *item_name;
+    }, "Get the name of an item from the cached list.",
+       py::arg("index"),
+       "Return item_name")
+    .def("get_item_library_file_name_by_collection_and_type",
+         [](Collections &self,
+            Collection const &collection,
+            CollectionItemType const &item_type,
+            std::string const &item_name) {
+      std::string const *file_name;
 
-            py::tuple re(2);
-            re[0] = *fileName;
-            re[1] = error;
-            return re;
-          },
-          py::arg("collection"),
-          py::arg("itemType"),
-          py::arg("itemName"),
-          "Return(fileName, error)")
+      int error = self.GetItemLibraryFileNameByCollectionAndType(
+        collection, item_type, item_name, &file_name);
+      if (error == 1) {
+        throw std::runtime_error(
+          "collection or item_type are unknown, or\nan item "
+          "with the specified type and name cannot be found "
+          "in the specified collection!");
+      }
 
-      .def(
-          "cache_list_of_item_metadata_files_by_collection_and_type",
-          [](Collections & self,
-             Collection const collection,
-             CollectionItemType const itemType,
-             std::string const & itemName) {
-            int extent;
-            int error = self.CacheListOfItemMetadataFilesByCollectionAndType(
-                collection, itemType, itemName, &extent);
+      return *file_name;
+    }, "Get the item's library file name.",
+       py::arg("collection"),
+       py::arg("item_type"),
+       py::arg("item_name"),
+       "Return file_name")
+    .def("cache_list_of_item_metadata_files_by_collection_and_type",
+         [](Collections &self,
+            Collection const &collection,
+            CollectionItemType const &item_type,
+            std::string const &item_name) {
+      int extent;
 
-            py::tuple re(2);
-            re[0] = extent;
-            re[1] = error;
-            return re;
-          },
-          py::arg("collection"),
-          py::arg("itemType"),
-          py::arg("itemName"),
-          "Return(extent, error)")
+      int error = self.CacheListOfItemMetadataFilesByCollectionAndType(
+        collection, item_type, item_name, &extent);
+      if (error == 1) {
+        throw std::runtime_error(
+          "collection or item_type are unknown, or\nthe list "
+          "is not successfully cached for some reason!");
+      }
 
-      .def(
-          "get_item_metadata_file_by_collection_and_type",
-          [](Collections & self, int const index) {
-            std::string const * fileName;
-            unsigned int fileLength;
-            unsigned char const * fileRawData;
-            int availableAsString;
-            std::string const * fileString;
-            int error = self.GetItemMetadataFileByCollectionAndType(
-                index,
-                &fileName,
-                &fileLength,
-                &fileRawData,
-                &availableAsString,
-                &fileString);
+      return extent;
+    }, "Cache a list of an item's metadata files.",
+       py::arg("collection"),
+       py::arg("item_type"),
+       py::arg("item_name"),
+       "Return extent")
+    .def("get_item_metadata_file_by_collection_and_type",
+         [](Collections &self, int const index) {
+      std::string const *file_name;
+      unsigned int file_length;
+      unsigned char const *file_raw_data;
+      int available_as_string;
+      std::string const *file_string;
 
-            py::tuple re(6);
-            re[0] = *fileName;
-            re[1] = fileLength;
-            re[2] = fileRawData;
-            re[3] = availableAsString;
-            re[4] = *fileString;
-            re[5] = error;
-            return re;
-          },
-          py::arg("index"),
-          "Return(fileName, fileLength, fileRawData, availableAsString, "
-          "fileString, error)")
+      int error = self.GetItemMetadataFileByCollectionAndType(
+        index,
+        &file_name,
+        &file_length,
+        &file_raw_data,
+        &available_as_string,
+        &file_string);
+      if (error == 1) {
+        throw std::runtime_error("index is invalid!");
+      }
 
-      .def(
-          "get_project_name_and_sem_ver",
-          [](Collections & self) {
-            std::string const * projectName;
-            std::string const * semVer;
-            self.GetProjectNameAndSemVer(&projectName, &semVer);
+      py::tuple re(5);
+      re[0] = *file_name;
+      re[1] = file_length;
+      re[2] = file_raw_data;
+      re[3] = available_as_string;
+      re[4] = *file_string;
+      return re;
+    }, "Get the name and content of one of an item's metadata files.",
+       py::arg("index"),
+       "Return(file_name, file_length, file_raw_data, "
+       "available_as_string, file_string)")
+    .def("get_project_name_and_sem_ver", [](Collections &self) {
+      std::string const *project_name;
+      std::string const *sem_ver;
 
-            py::tuple re(2);
-            re[0] = *projectName;
-            re[1] = *semVer;
-            return re;
-          },
-          "Return(projectName, semVer)")
+      self.GetProjectNameAndSemVer(&project_name, &sem_ver);
 
-      .def(
-          "get_environment_variable_name",
-          [](Collections & self, CollectionItemType const itemType) {
-            std::string const * name;
-            int error = self.GetEnvironmentVariableName(itemType, &name);
+      py::tuple re(2);
+      re[0] = *project_name;
+      re[1] = *sem_ver;
+      return re;
+    }, "Get the KIM-API project name and full Semantic Version string.",
+       "Return(project_name, sem_ver)")
+    .def("get_environment_variable_name",
+         [](Collections &self, CollectionItemType const &item_type) {
+      std::string const *name;
 
-            py::tuple re(2);
-            re[0] = *name;
-            re[1] = error;
-            return re;
-          },
-          py::arg("itemType"),
-          "Return(name, error)")
+      int error = self.GetEnvironmentVariableName(item_type, &name);
+      if (error == 1) {
+        throw std::runtime_error("item_type is unknown!");
+      }
 
-      .def(
-          "get_configuration_file_environment_variable",
-          [](Collections & self) {
-            std::string const * name;
-            std::string const * value;
-            self.GetConfigurationFileEnvironmentVariable(&name, &value);
+      return *name;
+    }, "Get the names of environment variables that store configuration "
+       "settings for the KIM::COLLECTION::environmentVariable collection.",
+       py::arg("item_type"),
+       "Return name")
+    .def("get_configuration_file_environment_variable",
+         [](Collections &self) {
+      std::string const *name;
+      std::string const *value;
 
-            py::tuple re(2);
-            re[0] = *name;
-            re[1] = *value;
-            return re;
-          },
-          "Return(name, value)")
+      self.GetConfigurationFileEnvironmentVariable(&name, &value);
 
-      .def(
-          "get_configuration_file_name",
-          [](Collections & self) {
-            std::string const * fileName;
-            self.GetConfigurationFileName(&fileName);
+      py::tuple re(2);
+      re[0] = *name;
+      re[1] = *value;
+      return re;
+    }, "Get the name and value of the environment variable that stores the "
+       "name of the KIM-API user configuration file.",
+       "Return(name, value)")
+    .def("get_configuration_file_name", [](Collections &self) {
+      std::string const *file_name;
 
-            return *fileName;
-          },
-          "Return fileName")
+      self.GetConfigurationFileName(&file_name);
 
-      .def(
-          "cache_list_of_directory_names",
-          [](Collections & self,
-             Collection const collection,
-             CollectionItemType const itemType) {
-            int extent;
-            int error
-                = self.CacheListOfDirectoryNames(collection, itemType, &extent);
+      return *file_name;
+    }, "Get the absolute file and path name of the KIM-API user "
+       "configuration file.",
+       "Return file_name")
+    .def("cache_list_of_directory_names",
+         [](Collections &self,
+            Collection const &collection,
+            CollectionItemType const &item_type) {
+      int extent;
 
-            py::tuple re(2);
-            re[0] = extent;
-            re[1] = error;
-            return re;
-          },
-          py::arg("collection"),
-          py::arg("itemType"),
-          "Return(extent, error)")
+      int error =
+        self.CacheListOfDirectoryNames(collection, item_type, &extent);
+      if (error == 1) {
+        throw std::runtime_error(
+          "collection or item_type are unknown! or\n"
+          "the list is not successfully cached for some reason!");
+      }
 
-      .def(
-          "get_directory_name",
-          [](Collections & self, int const index) {
-            std::string const * directoryName;
-            int error = self.GetDirectoryName(index, &directoryName);
+      return extent;
+    }, "Cache a list of directory names where a specific KIM-API "
+       "collection stores library files for a specific item type.",
+       py::arg("collection"),
+       py::arg("item_type"),
+       "Return extent")
+    .def("get_directory_name", [](Collections &self, int const index) {
+      std::string const *directory_name;
 
-            py::tuple re(2);
-            re[0] = *directoryName;
-            re[1] = error;
-            return re;
-          },
-          py::arg("index"),
-          "Return(directoryName, error)")
+      int error = self.GetDirectoryName(index, &directory_name);
+      if (error == 1) {
+        throw std::runtime_error("index is invalid!");
+      }
 
-      .def("set_log_id", &Collections::SetLogID)
+      return *directory_name;
+    }, "Get the name of a directory from the cached list.",
+       py::arg("index"),
+       "Return directory_name")
+    .def("set_log_id", &Collections::SetLogID,
+         "Set the identity of the Log object associated with the "
+         "collections object.",
+         py::arg("log_id"))
+    .def("push_log_verbosity", &Collections::PushLogVerbosity,
+         "Push a new log_verbosity onto the collections object's Log object "
+         "verbosity stack.",
+         py::arg("log_verbosity"))
+    .def("pop_log_verbosity", &Collections::PopLogVerbosity,
+         "Pop a log_verbosity from the collections object's Log object "
+         "verbosity stack.");
 
-      .def("push_log_verbosity", &Collections::PushLogVerbosity)
+  module.def("create", []() {
+    Collections *collections;
 
-      .def("pop_log_verbosity", &Collections::PopLogVerbosity);
+    int error = Collections::Create(&collections);
+    if (error == 1) {
+      throw std::runtime_error(
+        "Unable to create a new KIM-API collections object!");
+    }
 
-
-  // module functions
-
-  module.def(
-      "create",
-      []() {
-        Collections * co;
-        int error = Collections::Create(&co);
-
-        py::tuple re(2);
-        re[0] = co;
-        re[1] = error;
-        return re;
-      },
-      "Return(Collections, error)");
-
-  module.def("destroy",
-             [](Collections * self) { Collections::Destroy(&self); });
+    return std::unique_ptr<Collections, PyCollectionsDestroy>(
+      std::move(collections));
+  }, "Create a new KIM-API collections object.",
+     "Return collections");
 }

--- a/kimpy/KIM_Collections_bind.cpp
+++ b/kimpy/KIM_Collections_bind.cpp
@@ -10,48 +10,53 @@ namespace py = pybind11;
 using namespace KIM;
 
 
-namespace{
-struct PyCollectionsDestroy {
-  void operator()(Collections *collections) const {
+namespace
+{
+struct PyCollectionsDestroy
+{
+  void operator()(Collections * collections) const
+  {
     Collections::Destroy(&collections);
   }
 };
-} // namespace
+}  // namespace
 
 
 PYBIND11_MODULE(collections, module)
 {
   module.doc() = "Python binding to KIM_Collections.hpp";
 
-  py::class_<Collections, std::unique_ptr<Collections, PyCollectionsDestroy>>
-    cl(module, "Collections");
+  py::class_<Collections, std::unique_ptr<Collections, PyCollectionsDestroy> >
+      cl(module, "Collections");
 
   // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([]() {
-      Collections *collections;
+    Collections * collections;
 
-      int error = Collections::Create(&collections);
-      if (error == 1) {
-        throw std::runtime_error(
-          "Unable to create a new KIM-API collections object!");
-      }
+    int error = Collections::Create(&collections);
+    if (error == 1)
+    {
+      throw std::runtime_error(
+          "Unable to create a new KIM-API Collections object!");
+    }
 
-      return std::unique_ptr<Collections, PyCollectionsDestroy>(
+    return std::unique_ptr<Collections, PyCollectionsDestroy>(
         std::move(collections));
     }))
     .def("get_item_type",
          [](Collections &self, std::string const &item_name) {
-      CollectionItemType collection_item_type;
+    CollectionItemType collection_item_type;
 
-      int error = self.GetItemType(item_name, &collection_item_type);
-      if (error == 1) {
-        throw std::runtime_error(
+    int error = self.GetItemType(item_name, &collection_item_type);
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "An item with the specificed name cannot be found!");
-      }
+    }
 
-      return collection_item_type;
+    return collection_item_type;
     }, R"pbdoc(
-       Get the collection_item_type of the item in the KIM-API collections with
+       Get the collection_item_type of the item in the KIM-API Collections with
        a specific name.
 
        Returns:
@@ -62,22 +67,23 @@ PYBIND11_MODULE(collections, module)
          [](Collections &self,
             CollectionItemType const &item_type,
             std::string const &item_name) {
-      std::string const *file_name;
+    std::string const * file_name;
 
-      Collection collection;
+    Collection collection;
 
-      int error = self.GetItemLibraryFileNameAndCollection(
+    int error = self.GetItemLibraryFileNameAndCollection(
         item_type, item_name, &file_name, &collection);
-      if (error == 1) {
-        throw std::runtime_error(
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "item_type is unknown!  or\nan item with the specified type "
           "and name cannot be found!");
-      }
+    }
 
-      py::tuple re(2);
-      re[0] = *file_name;
-      re[1] = collection;
-      return re;
+    py::tuple re(2);
+    re[0] = *file_name;
+    re[1] = collection;
+    return re;
     }, R"pbdoc(
        Get the item's library file name and its KIM::Collection.
 
@@ -90,17 +96,18 @@ PYBIND11_MODULE(collections, module)
          [](Collections &self,
             CollectionItemType const &item_type,
             std::string const &item_name) {
-      int extent;
+    int extent;
 
-      int error = self.CacheListOfItemMetadataFiles(
-        item_type, item_name, &extent);
-      if (error == 1) {
-        throw std::runtime_error(
+    int error
+        = self.CacheListOfItemMetadataFiles(item_type, item_name, &extent);
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "item_type is unknown!  or\nthe list is not successfully cached "
           "for some reason!");
-      }
+    }
 
-      return extent;
+    return extent;
     }, R"pbdoc(
        Cache a list of an item's metadata files.
 
@@ -111,29 +118,27 @@ PYBIND11_MODULE(collections, module)
        py::arg("item_name"))
     .def("get_item_metadata_file",
          [](Collections &self, int const index) {
-      std::string const *file_name;
-      unsigned int file_length;
-      unsigned char const *file_raw_data;
-      int available_as_string;
-      std::string const *file_string;
+    std::string const * file_name;
+    unsigned int file_length;
+    unsigned char const * file_raw_data;
+    int available_as_string;
+    std::string const * file_string;
 
-      int error = self.GetItemMetadataFile(index,
-                                           &file_name,
-                                           &file_length,
-                                           &file_raw_data,
-                                           &available_as_string,
-                                           &file_string);
-      if (error == 1) {
-        throw std::runtime_error("index is invalid!");
-      }
+    int error = self.GetItemMetadataFile(index,
+                                         &file_name,
+                                         &file_length,
+                                         &file_raw_data,
+                                         &available_as_string,
+                                         &file_string);
+    if (error == 1) { throw std::runtime_error("index is invalid!"); }
 
-      py::tuple re(5);
-      re[0] = *file_name;
-      re[1] = file_length;
-      re[2] = file_raw_data;
-      re[3] = available_as_string;
-      re[4] = *file_string;
-      return re;
+    py::tuple re(5);
+    re[0] = *file_name;
+    re[1] = file_length;
+    re[2] = file_raw_data;
+    re[3] = available_as_string;
+    re[4] = *file_string;
+    return re;
     }, R"pbdoc(
        Get the name and content of one of an item's metadata files.
 
@@ -144,31 +149,27 @@ PYBIND11_MODULE(collections, module)
        py::arg("index"))
     .def("cache_list_of_item_names_by_type",
          [](Collections &self, CollectionItemType const &item_type) {
-      int extent;
+    int extent;
 
-      int error = self.CacheListOfItemNamesByType(item_type, &extent);
-      if (error == 1) {
-        throw std::runtime_error("item_type is unknown!");
-      }
+    int error = self.CacheListOfItemNamesByType(item_type, &extent);
+    if (error == 1) { throw std::runtime_error("item_type is unknown!"); }
 
-      return extent;
+    return extent;
     }, R"pbdoc(
        Cache a list of all item names of a specific type in the KIM-API
-       collections.
+       Collections.
 
        Returns:
            int: extent
        )pbdoc",
        py::arg("item_type"))
     .def("get_item_name_by_type", [](Collections &self, int const index) {
-      std::string const *item_name;
+    std::string const * item_name;
 
-      int error = self.GetItemNameByType(index, &item_name);
-      if (error == 1) {
-        throw std::runtime_error("index is invalid!");
-      }
+    int error = self.GetItemNameByType(index, &item_name);
+    if (error == 1) { throw std::runtime_error("index is invalid!"); }
 
-      return *item_name;
+    return *item_name;
     }, R"pbdoc(
        Get the name of an item from the cached list.
 
@@ -180,15 +181,16 @@ PYBIND11_MODULE(collections, module)
          [](Collections &self,
             Collection const &collection,
             CollectionItemType const &item_type) {
-      int extent;
+    int extent;
 
-      int error = self.CacheListOfItemNamesByCollectionAndType(
+    int error = self.CacheListOfItemNamesByCollectionAndType(
         collection, item_type, &extent);
-      if (error == 1) {
-        throw std::runtime_error("collection or item_type are unknown!");
-      }
+    if (error == 1)
+    {
+      throw std::runtime_error("collection or item_type are unknown!");
+    }
 
-      return extent;
+    return extent;
     }, R"pbdoc(
        Cache a list of all item names of a specific type in a specific
        collection.
@@ -200,14 +202,12 @@ PYBIND11_MODULE(collections, module)
        py::arg("item_type"))
     .def("get_item_name_by_collection_and_type",
          [](Collections &self, int const index) {
-      std::string const *item_name;
+    std::string const * item_name;
 
-      int error = self.GetItemNameByCollectionAndType(index, &item_name);
-      if (error == 1) {
-        throw std::runtime_error("index is invalid!");
-      }
+    int error = self.GetItemNameByCollectionAndType(index, &item_name);
+    if (error == 1) { throw std::runtime_error("index is invalid!"); }
 
-      return *item_name;
+    return *item_name;
     }, R"pbdoc(
        Get the name of an item from the cached list.
 
@@ -220,18 +220,19 @@ PYBIND11_MODULE(collections, module)
             Collection const &collection,
             CollectionItemType const &item_type,
             std::string const &item_name) {
-      std::string const *file_name;
+    std::string const * file_name;
 
-      int error = self.GetItemLibraryFileNameByCollectionAndType(
+    int error = self.GetItemLibraryFileNameByCollectionAndType(
         collection, item_type, item_name, &file_name);
-      if (error == 1) {
-        throw std::runtime_error(
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "collection or item_type are unknown, or\nan item "
           "with the specified type and name cannot be found "
           "in the specified collection!");
-      }
+    }
 
-      return *file_name;
+    return *file_name;
     }, R"pbdoc(
        Get the item's library file name.
 
@@ -246,17 +247,18 @@ PYBIND11_MODULE(collections, module)
             Collection const &collection,
             CollectionItemType const &item_type,
             std::string const &item_name) {
-      int extent;
+    int extent;
 
-      int error = self.CacheListOfItemMetadataFilesByCollectionAndType(
+    int error = self.CacheListOfItemMetadataFilesByCollectionAndType(
         collection, item_type, item_name, &extent);
-      if (error == 1) {
-        throw std::runtime_error(
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "collection or item_type are unknown, or\nthe list "
           "is not successfully cached for some reason!");
-      }
+    }
 
-      return extent;
+    return extent;
     }, R"pbdoc(
        Cache a list of an item's metadata files.
 
@@ -268,30 +270,28 @@ PYBIND11_MODULE(collections, module)
        py::arg("item_name"))
     .def("get_item_metadata_file_by_collection_and_type",
          [](Collections &self, int const index) {
-      std::string const *file_name;
-      unsigned int file_length;
-      unsigned char const *file_raw_data;
-      int available_as_string;
-      std::string const *file_string;
+    std::string const * file_name;
+    unsigned int file_length;
+    unsigned char const * file_raw_data;
+    int available_as_string;
+    std::string const * file_string;
 
-      int error = self.GetItemMetadataFileByCollectionAndType(
-        index,
-        &file_name,
-        &file_length,
-        &file_raw_data,
-        &available_as_string,
-        &file_string);
-      if (error == 1) {
-        throw std::runtime_error("index is invalid!");
-      }
+    int error
+        = self.GetItemMetadataFileByCollectionAndType(index,
+                                                      &file_name,
+                                                      &file_length,
+                                                      &file_raw_data,
+                                                      &available_as_string,
+                                                      &file_string);
+    if (error == 1) { throw std::runtime_error("index is invalid!"); }
 
-      py::tuple re(5);
-      re[0] = *file_name;
-      re[1] = file_length;
-      re[2] = file_raw_data;
-      re[3] = available_as_string;
-      re[4] = *file_string;
-      return re;
+    py::tuple re(5);
+    re[0] = *file_name;
+    re[1] = file_length;
+    re[2] = file_raw_data;
+    re[3] = available_as_string;
+    re[4] = *file_string;
+    return re;
     }, R"pbdoc(
        Get the name and content of one of an item's metadata files.
 
@@ -301,15 +301,15 @@ PYBIND11_MODULE(collections, module)
        )pbdoc",
        py::arg("index"))
     .def("get_project_name_and_sem_ver", [](Collections &self) {
-      std::string const *project_name;
-      std::string const *sem_ver;
+    std::string const * project_name;
+    std::string const * sem_ver;
 
-      self.GetProjectNameAndSemVer(&project_name, &sem_ver);
+    self.GetProjectNameAndSemVer(&project_name, &sem_ver);
 
-      py::tuple re(2);
-      re[0] = *project_name;
-      re[1] = *sem_ver;
-      return re;
+    py::tuple re(2);
+    re[0] = *project_name;
+    re[1] = *sem_ver;
+    return re;
     }, R"pbdoc(
        Get the KIM-API project name and full Semantic Version string.
 
@@ -318,14 +318,12 @@ PYBIND11_MODULE(collections, module)
        )pbdoc")
     .def("get_environment_variable_name",
          [](Collections &self, CollectionItemType const &item_type) {
-      std::string const *name;
+    std::string const * name;
 
-      int error = self.GetEnvironmentVariableName(item_type, &name);
-      if (error == 1) {
-        throw std::runtime_error("item_type is unknown!");
-      }
+    int error = self.GetEnvironmentVariableName(item_type, &name);
+    if (error == 1) { throw std::runtime_error("item_type is unknown!"); }
 
-      return *name;
+    return *name;
     }, R"pbdoc(
        Get the names of environment variables that store configuration
        settings for the KIM::COLLECTION::environmentVariable collection.
@@ -336,15 +334,15 @@ PYBIND11_MODULE(collections, module)
        py::arg("item_type"))
     .def("get_configuration_file_environment_variable",
          [](Collections &self) {
-      std::string const *name;
-      std::string const *value;
+    std::string const * name;
+    std::string const * value;
 
-      self.GetConfigurationFileEnvironmentVariable(&name, &value);
+    self.GetConfigurationFileEnvironmentVariable(&name, &value);
 
-      py::tuple re(2);
-      re[0] = *name;
-      re[1] = *value;
-      return re;
+    py::tuple re(2);
+    re[0] = *name;
+    re[1] = *value;
+    return re;
     }, R"pbdoc(
        Get the name and value of the environment variable that stores the
        name of the KIM-API user configuration file.
@@ -353,11 +351,11 @@ PYBIND11_MODULE(collections, module)
            str, str: name, value
        )pbdoc")
     .def("get_configuration_file_name", [](Collections &self) {
-      std::string const *file_name;
+    std::string const * file_name;
 
-      self.GetConfigurationFileName(&file_name);
+    self.GetConfigurationFileName(&file_name);
 
-      return *file_name;
+    return *file_name;
     }, R"pbdoc(
        Get the absolute file and path name of the KIM-API user configuration
        file.
@@ -369,20 +367,20 @@ PYBIND11_MODULE(collections, module)
          [](Collections &self,
             Collection const &collection,
             CollectionItemType const &item_type) {
-      int extent;
+    int extent;
 
-      int error =
-        self.CacheListOfDirectoryNames(collection, item_type, &extent);
-      if (error == 1) {
-        throw std::runtime_error(
+    int error = self.CacheListOfDirectoryNames(collection, item_type, &extent);
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "collection or item_type are unknown! or\n"
           "the list is not successfully cached for some reason!");
-      }
+    }
 
-      return extent;
+    return extent;
     }, R"pbdoc(
        Cache a list of directory names where a specific KIM-API
-       collection stores library files for a specific item type.
+       Collection stores library files for a specific item type.
 
        Returns:
            int: extent
@@ -390,14 +388,12 @@ PYBIND11_MODULE(collections, module)
        py::arg("collection"),
        py::arg("item_type"))
     .def("get_directory_name", [](Collections &self, int const index) {
-      std::string const *directory_name;
+    std::string const * directory_name;
 
-      int error = self.GetDirectoryName(index, &directory_name);
-      if (error == 1) {
-        throw std::runtime_error("index is invalid!");
-      }
+    int error = self.GetDirectoryName(index, &directory_name);
+    if (error == 1) { throw std::runtime_error("index is invalid!"); }
 
-      return *directory_name;
+    return *directory_name;
     }, R"pbdoc(
        Get the name of a directory from the cached list.
 
@@ -417,21 +413,25 @@ PYBIND11_MODULE(collections, module)
          "Pop a log_verbosity from the collections object's Log object "
          "verbosity stack.");
 
-  module.def("create", []() {
-    Collections *collections;
+  module.def(
+      "create",
+      []() {
+    Collections * collections;
 
     int error = Collections::Create(&collections);
-    if (error == 1) {
+    if (error == 1)
+    {
       throw std::runtime_error(
-        "Unable to create a new KIM-API collections object!");
+          "Unable to create a new KIM-API Collections object!");
     }
 
     return std::unique_ptr<Collections, PyCollectionsDestroy>(
-      std::move(collections));
-  }, R"pbdoc(
-       Create a new KIM-API collections object.
+        std::move(collections));
+      }, R"pbdoc(
+         Create a new KIM-API Collections object.
 
-       Returns:
-           Collections: collections
-       )pbdoc");
+         Returns:
+             Collections: collections
+         )pbdoc"
+      );
 }

--- a/kimpy/KIM_ComputeArgumentName_bind.cpp
+++ b/kimpy/KIM_ComputeArgumentName_bind.cpp
@@ -61,9 +61,13 @@ PYBIND11_MODULE(compute_argument_name, module)
     }
 
     return compute_argument_name;
-  }, "Get the identity of each defined standard compute_argument_name.",
-     py::arg("index"),
-     "Return compute_argument_name");
+  }, R"pbdoc(
+     Get the identity of each defined standard compute_argument_name.
+
+     Returns:
+         compute_argument_name
+     )pbdoc",
+     py::arg("index"));
 
   module.def("get_number_of_compute_argument_names", []() {
     int number_of_compute_arguments;
@@ -72,9 +76,12 @@ PYBIND11_MODULE(compute_argument_name, module)
         &number_of_compute_arguments);
 
     return number_of_compute_arguments;
-  }, "Get the number of standard compute_argument_name's "
-     "defined by the KIM-API.",
-     "Return number_of_compute_arguments");
+  }, R"pbdoc(
+     Get the number of standard compute_argument_name's defined by the KIM-API.
+
+     Returns:
+         int: number_of_compute_arguments
+     )pbdoc");
 
   module.def("get_compute_argument_data_type",
       [](ComputeArgumentName const &compute_argument_name) {
@@ -87,9 +94,13 @@ PYBIND11_MODULE(compute_argument_name, module)
     }
 
     return data_type;
-  }, "Get the data_type of each defined standard compute_argument_name.",
-     py::arg("compute_argument_name"),
-     "Return data_type");
+  }, R"pbdoc(
+     Get the data_type of each defined standard compute_argument_name.
+
+     Returns:
+         DataType: data_type
+     )pbdoc",
+     py::arg("compute_argument_name"));
 
   // attrributes
 

--- a/kimpy/KIM_ComputeArgumentName_bind.cpp
+++ b/kimpy/KIM_ComputeArgumentName_bind.cpp
@@ -23,30 +23,28 @@ PYBIND11_MODULE(compute_argument_name, module)
   py::class_<ComputeArgumentName> cl(module, "ComputeArgumentName");
 
   cl.def(py::init<>())
-    .def(py::init<int const>())
-    .def(py::init<std::string const>())
-    .def("known", &ComputeArgumentName::Known,
-         "Determines if the object is a quantity known to the KIM-API.")
-    .def(py::self == py::self)
-    .def(py::self != py::self)
-    .def("__repr__", &ComputeArgumentName::ToString)
-    .def(py::pickle(
-      // __getstate__
-      [](ComputeArgumentName const &compute_argument_name) {
-        // Return a tuple that fully encodes
-        // the state of the compute_argument_name object
-        return py::make_tuple(compute_argument_name.computeArgumentNameID);
-      },
-      // __setstate__
-      [](py::tuple t) {
-        if (t.size() != 1) {
-          throw std::runtime_error("Invalid state!");
-        }
-        // Create a new instance
-        ComputeArgumentName compute_argument_name(t[0].cast<int>());
-        return compute_argument_name;
-      }
-    ));
+      .def(py::init<int const>())
+      .def(py::init<std::string const>())
+      .def("known",
+           &ComputeArgumentName::Known,
+           "Determines if the object is a quantity known to the KIM-API.")
+      .def(py::self == py::self)
+      .def(py::self != py::self)
+      .def("__repr__", &ComputeArgumentName::ToString)
+      .def(py::pickle(
+          // __getstate__
+          [](ComputeArgumentName const & compute_argument_name) {
+            // Return a tuple that fully encodes
+            // the state of the compute_argument_name object
+            return py::make_tuple(compute_argument_name.computeArgumentNameID);
+          },
+          // __setstate__
+          [](py::tuple t) {
+            if (t.size() != 1) { throw std::runtime_error("Invalid state!"); }
+            // Create a new instance
+            ComputeArgumentName compute_argument_name(t[0].cast<int>());
+            return compute_argument_name;
+          }));
 
   // functions
 
@@ -54,10 +52,11 @@ PYBIND11_MODULE(compute_argument_name, module)
     ComputeArgumentName compute_argument_name;
 
     int error = COMPUTE_ARGUMENT_NAME::GetComputeArgumentName(
-      index, &compute_argument_name);
-    if (error == 1) {
+        index, &compute_argument_name);
+    if (error == 1)
+    {
       throw std::runtime_error(
-        "index < 0 or index >= number_of_compute_argument_names!");
+          "index < 0 or index >= number_of_compute_argument_names!");
     }
 
     return compute_argument_name;
@@ -88,8 +87,9 @@ PYBIND11_MODULE(compute_argument_name, module)
     DataType data_type;
 
     int error = COMPUTE_ARGUMENT_NAME::GetComputeArgumentDataType(
-      compute_argument_name, &data_type);
-    if (error == 1) {
+        compute_argument_name, &data_type);
+    if (error == 1)
+    {
       throw std::runtime_error("compute_argument_name is unknown!");
     }
 
@@ -105,16 +105,16 @@ PYBIND11_MODULE(compute_argument_name, module)
   // attrributes
 
   module.attr("numberOfParticles") = COMPUTE_ARGUMENT_NAME::numberOfParticles;
-  module.attr("particleSpeciesCodes") =
-    COMPUTE_ARGUMENT_NAME::particleSpeciesCodes;
-  module.attr("particleContributing") =
-    COMPUTE_ARGUMENT_NAME::particleContributing;
+  module.attr("particleSpeciesCodes")
+      = COMPUTE_ARGUMENT_NAME::particleSpeciesCodes;
+  module.attr("particleContributing")
+      = COMPUTE_ARGUMENT_NAME::particleContributing;
   module.attr("coordinates") = COMPUTE_ARGUMENT_NAME::coordinates;
   module.attr("partialEnergy") = COMPUTE_ARGUMENT_NAME::partialEnergy;
   module.attr("partialForces") = COMPUTE_ARGUMENT_NAME::partialForces;
-  module.attr("partialParticleEnergy") =
-    COMPUTE_ARGUMENT_NAME::partialParticleEnergy;
+  module.attr("partialParticleEnergy")
+      = COMPUTE_ARGUMENT_NAME::partialParticleEnergy;
   module.attr("partialVirial") = COMPUTE_ARGUMENT_NAME::partialVirial;
-  module.attr("partialParticleVirial") =
-    COMPUTE_ARGUMENT_NAME::partialParticleVirial;
+  module.attr("partialParticleVirial")
+      = COMPUTE_ARGUMENT_NAME::partialParticleVirial;
 }

--- a/kimpy/KIM_ComputeArgumentName_bind.cpp
+++ b/kimpy/KIM_ComputeArgumentName_bind.cpp
@@ -6,7 +6,8 @@
 #include <string>
 
 #include "KIM_ComputeArgumentName.hpp"
-#include "KIM_DataType.hpp"  // Forward declaration in KIM_ComputeArgumentName.hpp
+// Forward declaration in KIM_ComputeArgumentName.hpp
+#include "KIM_DataType.hpp"
 
 namespace py = pybind11;
 using namespace py::literals;
@@ -17,71 +18,92 @@ PYBIND11_MODULE(compute_argument_name, module)
 {
   module.doc() = "Python binding to KIM_ComputeCallbackName.hpp";
 
-
   // classes
 
   py::class_<ComputeArgumentName> cl(module, "ComputeArgumentName");
-  cl.def(py::init<>())
-      .def(py::init<int const>())
-      .def(py::init<std::string const>())
-      .def("known", &ComputeArgumentName::Known)
-      .def(py::self == py::self)
-      .def(py::self != py::self)
-      .def("__repr__", &ComputeArgumentName::ToString);
 
+  cl.def(py::init<>())
+    .def(py::init<int const>())
+    .def(py::init<std::string const>())
+    .def("known", &ComputeArgumentName::Known,
+         "Determines if the object is a quantity known to the KIM-API.")
+    .def(py::self == py::self)
+    .def(py::self != py::self)
+    .def("__repr__", &ComputeArgumentName::ToString)
+    .def(py::pickle(
+      // __getstate__
+      [](ComputeArgumentName const &compute_argument_name) {
+        // Return a tuple that fully encodes
+        // the state of the compute_argument_name object
+        return py::make_tuple(compute_argument_name.computeArgumentNameID);
+      },
+      // __setstate__
+      [](py::tuple t) {
+        if (t.size() != 1) {
+          throw std::runtime_error("Invalid state!");
+        }
+        // Create a new instance
+        ComputeArgumentName compute_argument_name(t[0].cast<int>());
+        return compute_argument_name;
+      }
+    ));
 
   // functions
 
-  module.def(
-      "get_compute_argument_name",
-      [](int const index) {
-        ComputeArgumentName computeArgumentName;
-        int error = COMPUTE_ARGUMENT_NAME::GetComputeArgumentName(
-            index, &computeArgumentName);
+  module.def("get_compute_argument_name", [](int const index) {
+    ComputeArgumentName compute_argument_name;
 
-        py::tuple re(2);
-        re[0] = computeArgumentName;
-        re[1] = error;
-        return re;
-      },
-      py::arg("index"),
-      "Return(ComputeArgumentName, error)");
+    int error = COMPUTE_ARGUMENT_NAME::GetComputeArgumentName(
+      index, &compute_argument_name);
+    if (error == 1) {
+      throw std::runtime_error(
+        "index < 0 or index >= number_of_compute_argument_names!");
+    }
+
+    return compute_argument_name;
+  }, "Get the identity of each defined standard compute_argument_name.",
+     py::arg("index"),
+     "Return compute_argument_name");
 
   module.def("get_number_of_compute_argument_names", []() {
-    int numberOfComputeArguments;
+    int number_of_compute_arguments;
+
     COMPUTE_ARGUMENT_NAME::GetNumberOfComputeArgumentNames(
-        &numberOfComputeArguments);
-    return numberOfComputeArguments;
-  }, "Return numberOfComputeArguments");
+        &number_of_compute_arguments);
 
-  module.def(
-      "get_compute_argument_data_type",
-      [](ComputeArgumentName const computeArgumentName) {
-        DataType dataType;
-        bool error = COMPUTE_ARGUMENT_NAME::GetComputeArgumentDataType(
-            computeArgumentName, &dataType);
+    return number_of_compute_arguments;
+  }, "Get the number of standard compute_argument_name's "
+     "defined by the KIM-API.",
+     "Return number_of_compute_arguments");
 
-        py::tuple re(2);
-        re[0] = dataType;
-        re[1] = error;
-        return re;
-      },
-      py::arg("ComputeArgumentName"),
-      "Return(DataType, error)");
+  module.def("get_compute_argument_data_type",
+      [](ComputeArgumentName const &compute_argument_name) {
+    DataType data_type;
 
+    int error = COMPUTE_ARGUMENT_NAME::GetComputeArgumentDataType(
+      compute_argument_name, &data_type);
+    if (error == 1) {
+      throw std::runtime_error("compute_argument_name is unknown!");
+    }
+
+    return data_type;
+  }, "Get the data_type of each defined standard compute_argument_name.",
+     py::arg("compute_argument_name"),
+     "Return data_type");
 
   // attrributes
+
   module.attr("numberOfParticles") = COMPUTE_ARGUMENT_NAME::numberOfParticles;
-  module.attr("particleSpeciesCodes")
-      = COMPUTE_ARGUMENT_NAME::particleSpeciesCodes;
-  module.attr("particleContributing")
-      = COMPUTE_ARGUMENT_NAME::particleContributing;
+  module.attr("particleSpeciesCodes") =
+    COMPUTE_ARGUMENT_NAME::particleSpeciesCodes;
+  module.attr("particleContributing") =
+    COMPUTE_ARGUMENT_NAME::particleContributing;
   module.attr("coordinates") = COMPUTE_ARGUMENT_NAME::coordinates;
   module.attr("partialEnergy") = COMPUTE_ARGUMENT_NAME::partialEnergy;
   module.attr("partialForces") = COMPUTE_ARGUMENT_NAME::partialForces;
-  module.attr("partialParticleEnergy")
-      = COMPUTE_ARGUMENT_NAME::partialParticleEnergy;
+  module.attr("partialParticleEnergy") =
+    COMPUTE_ARGUMENT_NAME::partialParticleEnergy;
   module.attr("partialVirial") = COMPUTE_ARGUMENT_NAME::partialVirial;
-  module.attr("partialParticleVirial")
-      = COMPUTE_ARGUMENT_NAME::partialParticleVirial;
+  module.attr("partialParticleVirial") =
+    COMPUTE_ARGUMENT_NAME::partialParticleVirial;
 }

--- a/kimpy/KIM_ComputeArgumentName_bind.cpp
+++ b/kimpy/KIM_ComputeArgumentName_bind.cpp
@@ -30,21 +30,7 @@ PYBIND11_MODULE(compute_argument_name, module)
            "Determines if the object is a quantity known to the KIM-API.")
       .def(py::self == py::self)
       .def(py::self != py::self)
-      .def("__repr__", &ComputeArgumentName::ToString)
-      .def(py::pickle(
-          // __getstate__
-          [](ComputeArgumentName const & compute_argument_name) {
-            // Return a tuple that fully encodes
-            // the state of the compute_argument_name object
-            return py::make_tuple(compute_argument_name.computeArgumentNameID);
-          },
-          // __setstate__
-          [](py::tuple t) {
-            if (t.size() != 1) { throw std::runtime_error("Invalid state!"); }
-            // Create a new instance
-            ComputeArgumentName compute_argument_name(t[0].cast<int>());
-            return compute_argument_name;
-          }));
+      .def("__repr__", &ComputeArgumentName::ToString);
 
   // functions
 

--- a/kimpy/KIM_ComputeArgumentName_bind.cpp
+++ b/kimpy/KIM_ComputeArgumentName_bind.cpp
@@ -65,7 +65,7 @@ PYBIND11_MODULE(compute_argument_name, module)
      Get the identity of each defined standard compute_argument_name.
 
      Returns:
-         compute_argument_name
+         ComputeArgumentName: compute_argument_name
      )pbdoc",
      py::arg("index"));
 

--- a/kimpy/KIM_ComputeArguments_bind.cpp
+++ b/kimpy/KIM_ComputeArguments_bind.cpp
@@ -6,8 +6,8 @@
 
 #include "KIM_SimulatorHeaders.hpp"
 #include "callbacks.hpp"
-#include "sim_buffer.h"
 #include "py_kim_wrapper.h"
+#include "sim_buffer.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -18,38 +18,38 @@ PYBIND11_MODULE(compute_arguments, module)
 {
   module.doc() = "Python binding to KIM_ComputeArguments.hpp";
 
-  py::class_<PyComputeArguments, std::shared_ptr<PyComputeArguments>>
-      cl(module, "PyComputeArguments", py::dynamic_attr());
+  py::class_<PyComputeArguments, std::shared_ptr<PyComputeArguments> > cl(
+      module, "PyComputeArguments", py::dynamic_attr());
 
   // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([](std::shared_ptr<PyModel> model) {
-      std::shared_ptr<PyComputeArguments>
-        compute_arguments(new PyComputeArguments(model));
+    std::shared_ptr<PyComputeArguments> compute_arguments(
+        new PyComputeArguments(model));
 
-      int error =
-        model->_model->ComputeArgumentsCreate(
-          &compute_arguments->_compute_arguments);
-      if (error == 1) {
-        throw std::runtime_error(
-          "Unable to create a new compute_arguments object "
+    int error = model->_model->ComputeArgumentsCreate(
+        &compute_arguments->_compute_arguments);
+    if (error == 1)
+    {
+      throw std::runtime_error(
+          "Unable to create a new ComputeArguments object "
           "for the model object!");
-      }
+    }
 
-      return compute_arguments;
+    return compute_arguments;
     }))
     .def("get_argument_support_status",
          [](PyComputeArguments &self,
             ComputeArgumentName const &compute_argument_name) {
-      SupportStatus support_status;
+    SupportStatus support_status;
 
-      int error =
-        self._compute_arguments->GetArgumentSupportStatus(
-          compute_argument_name, &support_status);
-      if (error == 1) {
-        throw std::runtime_error("compute_argument_name is unknown!");
-      }
+    int error = self._compute_arguments->GetArgumentSupportStatus(
+        compute_argument_name, &support_status);
+    if (error == 1)
+    {
+      throw std::runtime_error("compute_argument_name is unknown!");
+    }
 
-      return support_status;
+    return support_status;
     }, R"pbdoc(
        Get the support_status of a compute_argument_name.
 
@@ -60,16 +60,16 @@ PYBIND11_MODULE(compute_arguments, module)
     .def("get_callback_support_status",
          [](PyComputeArguments &self,
             ComputeCallbackName const &compute_callback_name) {
-      SupportStatus support_status;
+    SupportStatus support_status;
 
-      int error =
-        self._compute_arguments->GetCallbackSupportStatus(
-          compute_callback_name, &support_status);
-      if (error == 1) {
-        throw std::runtime_error("compute_callback_name is unknown!");
-      }
+    int error = self._compute_arguments->GetCallbackSupportStatus(
+        compute_callback_name, &support_status);
+    if (error == 1)
+    {
+      throw std::runtime_error("compute_callback_name is unknown!");
+    }
 
-      return support_status;
+    return support_status;
     }, R"pbdoc(
        Get the support_status of a compute_callback_name.
 
@@ -81,14 +81,14 @@ PYBIND11_MODULE(compute_arguments, module)
          [](PyComputeArguments &self,
             ComputeArgumentName const &compute_argument_name,
             py::array_t<int> ptr) {
-      int *data = ptr.mutable_data(0);
+    int * data = ptr.mutable_data(0);
 
-      int error =
-        self._compute_arguments->SetArgumentPointer(
-          compute_argument_name, data);
-      if (error == 1) {
-        throw std::runtime_error("compute_argument_name is unknown!");
-      }
+    int error = self._compute_arguments->SetArgumentPointer(
+        compute_argument_name, data);
+    if (error == 1)
+    {
+      throw std::runtime_error("compute_argument_name is unknown!");
+    }
     }, "Set the data pointer for a compute_argument_name.",
        py::arg("compute_argument_name"),
        py::arg("ptr").noconvert())
@@ -96,26 +96,26 @@ PYBIND11_MODULE(compute_arguments, module)
          [](PyComputeArguments &self,
             ComputeArgumentName const &compute_argument_name,
             py::array_t<double> ptr) {
-      double *data = ptr.mutable_data(0);
+    double * data = ptr.mutable_data(0);
 
-      int error =
-        self._compute_arguments->SetArgumentPointer(
-          compute_argument_name, data);
-      if (error == 1) {
-        throw std::runtime_error("compute_argument_name is unknown!");
-      }
+    int error = self._compute_arguments->SetArgumentPointer(
+        compute_argument_name, data);
+    if (error == 1)
+    {
+      throw std::runtime_error("compute_argument_name is unknown!");
+    }
     }, "Set the data pointer for a compute_argument_name.",
        py::arg("compute_argument_name"),
        py::arg("ptr").noconvert())
     .def("set_argument_null_pointer",
          [](PyComputeArguments &self,
             ComputeArgumentName const &compute_argument_name) {
-      int error =
-        self._compute_arguments->SetArgumentPointer(
-          compute_argument_name, static_cast<double *>(nullptr));
-      if (error == 1) {
-        throw std::runtime_error("compute_argument_name is unknown!");
-      }
+    int error = self._compute_arguments->SetArgumentPointer(
+        compute_argument_name, static_cast<double *>(nullptr));
+    if (error == 1)
+    {
+      throw std::runtime_error("compute_argument_name is unknown!");
+    }
     }, "Set a null data pointer for a compute_argument_name.",
        py::arg("compute_argument_name"))
     .def("set_callback_pointer",
@@ -123,17 +123,18 @@ PYBIND11_MODULE(compute_arguments, module)
             ComputeCallbackName const &compute_callback_name,
             void const *const fptr, // cannot use: KIM::Function *const fptr
             void *const data_object) {
-      // the argument passed in is of type: void const *
-      // we cast type explicitly here
-      KIM::Function *new_fptr = (KIM::Function *) fptr;
+    // the argument passed in is of type: void const *
+    // we cast type explicitly here
+    KIM::Function * new_fptr = (KIM::Function *) fptr;
 
-      int error = self._compute_arguments->SetCallbackPointer(
+    int error = self._compute_arguments->SetCallbackPointer(
         compute_callback_name, LANGUAGE_NAME::cpp, new_fptr, data_object);
-      if (error == 1) {
-        throw std::runtime_error(
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "compute_callback_name is unknown!  or\n fptr is not NULL "
           "and compute_callback_name is notSupported!");
-      }
+    }
     }, "Set the function pointer for a compute_callback_name.",
        py::arg("compute_callback_name"),
        py::arg("callback_fn"),
@@ -143,67 +144,66 @@ PYBIND11_MODULE(compute_arguments, module)
             ComputeCallbackName const &compute_callback_name,
             py::object &pyfunc,
             py::dict &data_object) {
-      // pack python callback function and dataObject into a new dict
-      py::dict *pydict =
-        new py::dict("pyfunc"_a = pyfunc, "pydata"_a = data_object);
+    // pack python callback function and dataObject into a new dict
+    py::dict * pydict
+        = new py::dict("pyfunc"_a = pyfunc, "pydata"_a = data_object);
 
-      SimBuffer *sim_buffer;
+    SimBuffer * sim_buffer;
 
-      self._compute_arguments->GetSimulatorBufferPointer(
-        (void **) &sim_buffer);
+    self._compute_arguments->GetSimulatorBufferPointer((void **) &sim_buffer);
 
-      if (!sim_buffer)
-      {
-        sim_buffer = new SimBuffer;
+    if (!sim_buffer)
+    {
+      sim_buffer = new SimBuffer;
 
-        self._compute_arguments->SetSimulatorBufferPointer(
-          (void *) sim_buffer);
-      }
+      self._compute_arguments->SetSimulatorBufferPointer((void *) sim_buffer);
+    }
 
-      sim_buffer->callbacks.push_back(pydict);
+    sim_buffer->callbacks.push_back(pydict);
 
-      // select wrapper callback function
-      KIM::Function *wrap_fptr;
+    // select wrapper callback function
+    KIM::Function * wrap_fptr;
 
-      if (compute_callback_name == COMPUTE_CALLBACK_NAME::GetNeighborList)
-      {
-        wrap_fptr = reinterpret_cast<KIM::Function *>(&get_neigh);
-      }
-      else if (compute_callback_name == COMPUTE_CALLBACK_NAME::ProcessDEDrTerm)
-      {
-        wrap_fptr = reinterpret_cast<KIM::Function *>(&process_dEdr);
-      }
-      else if (
-        compute_callback_name == COMPUTE_CALLBACK_NAME::ProcessD2EDr2Term)
-      {
-        wrap_fptr = reinterpret_cast<KIM::Function *>(&process_d2Edr2);
-      }
-      else
-      {
-        throw std::runtime_error("compute_callback_name is unknown!");
-      }
+    if (compute_callback_name == COMPUTE_CALLBACK_NAME::GetNeighborList)
+    {
+      wrap_fptr = reinterpret_cast<KIM::Function *>(&get_neigh);
+    }
+    else if (compute_callback_name == COMPUTE_CALLBACK_NAME::ProcessDEDrTerm)
+    {
+      wrap_fptr = reinterpret_cast<KIM::Function *>(&process_dEdr);
+    }
+    else if (compute_callback_name == COMPUTE_CALLBACK_NAME::ProcessD2EDr2Term)
+    {
+      wrap_fptr = reinterpret_cast<KIM::Function *>(&process_d2Edr2);
+    }
+    else
+    {
+      throw std::runtime_error("compute_callback_name is unknown!");
+    }
 
-      // register callback to kim api
-      int error =
-        self._compute_arguments->SetCallbackPointer(
-          compute_callback_name, LANGUAGE_NAME::cpp, wrap_fptr,
-          reinterpret_cast<void *const>(pydict));
-      if (error == 1) {
-        throw std::runtime_error(
-          "fptr is not NULL and compute_callback_name is notSupported!");
-      }
+    // register callback to kim api
+    int error = self._compute_arguments->SetCallbackPointer(
+        compute_callback_name,
+        LANGUAGE_NAME::cpp,
+        wrap_fptr,
+        reinterpret_cast<void * const>(pydict));
+    if (error == 1)
+    {
+      throw std::runtime_error(
+          "fptr is not NULL and compute_callback_name is not Supported!");
+    }
     }, "Set the function pointer for a compute_callback_name.",
        py::arg("compute_callback_name"),
        py::arg("callback_fn"),
        py::arg("data_object"))
     .def("are_all_required_arguments_and_callbacks_present",
          [](PyComputeArguments &self) {
-      int result;
+    int result;
 
-      self._compute_arguments->AreAllRequiredArgumentsAndCallbacksPresent(
+    self._compute_arguments->AreAllRequiredArgumentsAndCallbacksPresent(
         &result);
 
-      return result;
+    return result;
     }, R"pbdoc(
        Determine if non-NULL pointers have been set for all
        compute_argument_name's and compute_callback_name's with support_status
@@ -213,23 +213,23 @@ PYBIND11_MODULE(compute_arguments, module)
            int: result
        )pbdoc")
     .def("__repr__", [](PyComputeArguments &self) {
-      return self._compute_arguments->ToString();
+    return self._compute_arguments->ToString();
     }, "Get a string representing the internal state of the "
-       "compute_arguments object")
+       "ComputeArguments object")
     .def("set_log_id",
          [](PyComputeArguments &self, std::string const &log_id) {
-      self._compute_arguments->SetLogID(log_id);
+    self._compute_arguments->SetLogID(log_id);
     }, "Set the identity of the Log object associated with the "
-       "compute_arguments object.",
+       "ComputeArguments object.",
        py::arg("log_id"))
     .def("push_log_verbosity",
          [](PyComputeArguments &self, LogVerbosity const &log_verbosity) {
-      self._compute_arguments->PushLogVerbosity(log_verbosity);
-    }, "Push a new log_verbosity onto the compute_arguments object's Log "
+    self._compute_arguments->PushLogVerbosity(log_verbosity);
+    }, "Push a new log_verbosity onto the ComputeArguments object's Log "
        "object verbosity stack.",
        py::arg("log_verbosity"))
     .def("pop_log_verbosity", [](PyComputeArguments &self) {
-      self._compute_arguments->PopLogVerbosity();
-    }, "Pop a log_verbosity from the compute_arguments object's Log object "
+    self._compute_arguments->PopLogVerbosity();
+    }, "Pop a log_verbosity from the ComputeArguments object's Log object "
        "verbosity stack.");
 }

--- a/kimpy/KIM_ComputeArguments_bind.cpp
+++ b/kimpy/KIM_ComputeArguments_bind.cpp
@@ -50,9 +50,13 @@ PYBIND11_MODULE(compute_arguments, module)
       }
 
       return support_status;
-    }, "Get the support_status of a compute_argument_name.",
-       py::arg("compute_argument_name"),
-       "Return support_status")
+    }, R"pbdoc(
+       Get the support_status of a compute_argument_name.
+
+       Returns:
+           SupportStatus: support_status
+       )pbdoc",
+       py::arg("compute_argument_name"))
     .def("get_callback_support_status",
          [](PyComputeArguments &self,
             ComputeCallbackName const &compute_callback_name) {
@@ -66,9 +70,13 @@ PYBIND11_MODULE(compute_arguments, module)
       }
 
       return support_status;
-    }, "Get the support_status of a compute_callback_name.",
-       py::arg("compute_callback_name"),
-       "Return support_status")
+    }, R"pbdoc(
+       Get the support_status of a compute_callback_name.
+
+       Returns:
+           SupportStatus: support_status
+       )pbdoc",
+       py::arg("compute_callback_name"))
     .def("set_argument_pointer",
          [](PyComputeArguments &self,
             ComputeArgumentName const &compute_argument_name,
@@ -196,10 +204,14 @@ PYBIND11_MODULE(compute_arguments, module)
         &result);
 
       return result;
-    }, "Determine if non-NULL pointers have been set for all "
-       "compute_argument_name's and compute_callback_name's with "
-       "support_status values of requiredByAPI or required.",
-       "Return result")
+    }, R"pbdoc(
+       Determine if non-NULL pointers have been set for all
+       compute_argument_name's and compute_callback_name's with support_status
+       values of required By API.
+
+       Returns:
+           int: result
+       )pbdoc")
     .def("__repr__", [](PyComputeArguments &self) {
       return self._compute_arguments->ToString();
     }, "Get a string representing the internal state of the "

--- a/kimpy/KIM_ComputeArguments_bind.cpp
+++ b/kimpy/KIM_ComputeArguments_bind.cpp
@@ -7,6 +7,7 @@
 #include "KIM_SimulatorHeaders.hpp"
 #include "callbacks.hpp"
 #include "sim_buffer.h"
+#include "py_kim_wrapper.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -17,174 +18,206 @@ PYBIND11_MODULE(compute_arguments, module)
 {
   module.doc() = "Python binding to KIM_ComputeArguments.hpp";
 
-  // C++ class constructor and destructor are private, which can not be wrapped
-  // directly.
-  // So we need to call the C++ class factory function in py::init, and use
-  // `py::nodelete` to avoid calling the destructor when python instance is
-  // destroyed. It is crucial that the instance is deallocated by calling the
-  // destroy function from the C++ side to avoid memory leaks. For more info,
-  // see http://pybind11.readthedocs.io/en/stable/advanced/classes.html
-
-  py::class_<ComputeArguments, std::unique_ptr<ComputeArguments, py::nodelete> >
-      cl(module, "ComputeArguments", py::dynamic_attr());
+  py::class_<PyComputeArguments, std::shared_ptr<PyComputeArguments>>
+      cl(module, "PyComputeArguments", py::dynamic_attr());
 
   // python constructor needs to return a pointer to the C++ instance
-  cl.def(py::init([](Model & mo, py::array_t<int> error) {
-      ComputeArguments * ca;
-      auto e = error.mutable_data(0);
-      e[0] = mo.ComputeArgumentsCreate(&ca);
-      return ca;
+  cl.def(py::init([](std::shared_ptr<PyModel> model) {
+      std::shared_ptr<PyComputeArguments>
+        compute_arguments(new PyComputeArguments(model));
+
+      int error =
+        model->_model->ComputeArgumentsCreate(
+          &compute_arguments->_compute_arguments);
+      if (error == 1) {
+        throw std::runtime_error(
+          "Unable to create a new compute_arguments object "
+          "for the model object!");
+      }
+
+      return compute_arguments;
     }))
+    .def("get_argument_support_status",
+         [](PyComputeArguments &self,
+            ComputeArgumentName const &compute_argument_name) {
+      SupportStatus support_status;
 
-      .def(
-          "get_argument_support_status",
-          [](ComputeArguments & self,
-             ComputeArgumentName const computeArgumentName) {
-            SupportStatus supportStatus;
-            int error = self.GetArgumentSupportStatus(computeArgumentName,
-                                                      &supportStatus);
+      int error =
+        self._compute_arguments->GetArgumentSupportStatus(
+          compute_argument_name, &support_status);
+      if (error == 1) {
+        throw std::runtime_error("compute_argument_name is unknown!");
+      }
 
-            py::tuple re(2);
-            re[0] = supportStatus;
-            re[1] = error;
-            return re;
-          },
-          py::arg("ComputeArgumentName"),
-          "Return(SupportStatus, error)")
+      return support_status;
+    }, "Get the support_status of a compute_argument_name.",
+       py::arg("compute_argument_name"),
+       "Return support_status")
+    .def("get_callback_support_status",
+         [](PyComputeArguments &self,
+            ComputeCallbackName const &compute_callback_name) {
+      SupportStatus support_status;
 
-      .def(
-          "get_callback_support_status",
-          [](ComputeArguments & self,
-             ComputeCallbackName const computeCallbackName) {
-            SupportStatus supportStatus;
-            int error = self.GetCallbackSupportStatus(computeCallbackName,
-                                                      &supportStatus);
+      int error =
+        self._compute_arguments->GetCallbackSupportStatus(
+          compute_callback_name, &support_status);
+      if (error == 1) {
+        throw std::runtime_error("compute_callback_name is unknown!");
+      }
 
-            py::tuple re(2);
-            re[0] = supportStatus;
-            re[1] = error;
-            return re;
-          },
-          py::arg("ComputeCallbackName"),
-          "Return(SupportStatus, error)")
+      return support_status;
+    }, "Get the support_status of a compute_callback_name.",
+       py::arg("compute_callback_name"),
+       "Return support_status")
+    .def("set_argument_pointer",
+         [](PyComputeArguments &self,
+            ComputeArgumentName const &compute_argument_name,
+            py::array_t<int> ptr) {
+      int *data = ptr.mutable_data(0);
 
-      .def(
-          "set_argument_pointer",
-          [](ComputeArguments & self,
-             ComputeArgumentName const computeArgumentName,
-             py::array_t<int> ptr) {
-            int * data = ptr.mutable_data(0);
-            int error = self.SetArgumentPointer(computeArgumentName, data);
-            return error;
-          },
-          py::arg("ComputeArgumentName"),
-          py::arg("ptr").noconvert())
+      int error =
+        self._compute_arguments->SetArgumentPointer(
+          compute_argument_name, data);
+      if (error == 1) {
+        throw std::runtime_error("compute_argument_name is unknown!");
+      }
+    }, "Set the data pointer for a compute_argument_name.",
+       py::arg("compute_argument_name"),
+       py::arg("ptr").noconvert())
+    .def("set_argument_pointer",
+         [](PyComputeArguments &self,
+            ComputeArgumentName const &compute_argument_name,
+            py::array_t<double> ptr) {
+      double *data = ptr.mutable_data(0);
 
-      .def(
-          "set_argument_pointer",
-          [](ComputeArguments & self,
-             ComputeArgumentName const computeArgumentName,
-             py::array_t<double> ptr) {
-            double * data = ptr.mutable_data(0);
-            int error = self.SetArgumentPointer(computeArgumentName, data);
-            return error;
-          },
-          py::arg("ComputeArgumentName"),
-          py::arg("ptr").noconvert())
+      int error =
+        self._compute_arguments->SetArgumentPointer(
+          compute_argument_name, data);
+      if (error == 1) {
+        throw std::runtime_error("compute_argument_name is unknown!");
+      }
+    }, "Set the data pointer for a compute_argument_name.",
+       py::arg("compute_argument_name"),
+       py::arg("ptr").noconvert())
+    .def("set_argument_null_pointer",
+         [](PyComputeArguments &self,
+            ComputeArgumentName const &compute_argument_name) {
+      int error =
+        self._compute_arguments->SetArgumentPointer(
+          compute_argument_name, static_cast<double *>(nullptr));
+      if (error == 1) {
+        throw std::runtime_error("compute_argument_name is unknown!");
+      }
+    }, "Set a null data pointer for a compute_argument_name.",
+       py::arg("compute_argument_name"))
+    .def("set_callback_pointer",
+         [](PyComputeArguments &self,
+            ComputeCallbackName const &compute_callback_name,
+            void const *const fptr, // cannot use: KIM::Function *const fptr
+            void *const data_object) {
+      // the argument passed in is of type: void const *
+      // we cast type explicitly here
+      KIM::Function *new_fptr = (KIM::Function *) fptr;
 
-      .def(
-          "set_argument_null_pointer",
-          [](ComputeArguments & self,
-             ComputeArgumentName const computeArgumentName) {
-            int error = self.SetArgumentPointer(
-                computeArgumentName, static_cast<double *>(nullptr));
-            return error;
-          },
-          py::arg("ComputeArgumentName"))
+      int error = self._compute_arguments->SetCallbackPointer(
+        compute_callback_name, LANGUAGE_NAME::cpp, new_fptr, data_object);
+      if (error == 1) {
+        throw std::runtime_error(
+          "compute_callback_name is unknown!  or\n fptr is not NULL "
+          "and compute_callback_name is notSupported!");
+      }
+    }, "Set the function pointer for a compute_callback_name.",
+       py::arg("compute_callback_name"),
+       py::arg("callback_fn"),
+       py::arg("data_object"))
+    .def("set_callback",
+         [](PyComputeArguments &self,
+            ComputeCallbackName const &compute_callback_name,
+            py::object &pyfunc,
+            py::dict &data_object) {
+      // pack python callback function and dataObject into a new dict
+      py::dict *pydict =
+        new py::dict("pyfunc"_a = pyfunc, "pydata"_a = data_object);
 
-      .def(
-          "set_callback_pointer",
-          [](ComputeArguments & self,
-             ComputeCallbackName const computeCallbackName,
-             void const * const
-                 fptr,  // cannot use: KIM::Function * const fptr
-                        // the argument passed in is of type: void const *
-                        // we cast type explicitly in the funciton body
-             void * const dataObject) {
-            KIM::Function * new_fptr = (KIM::Function *) fptr;
-            int error = self.SetCallbackPointer(
-                computeCallbackName, LANGUAGE_NAME::cpp, new_fptr, dataObject);
-            return error;
-          },
-          py::arg("ComputeCallbackName"),
-          py::arg("callback_fn"),
-          py::arg("dataObject"))
+      SimBuffer *sim_buffer;
 
-      .def(
-          "set_callback",
-          [](ComputeArguments & self,
-             ComputeCallbackName const computeCallbackName,
-             py::object & pyfunc,
-             py::dict & dataObject) {
-            // pack python callback function and dataObject into a new dict
-            py::dict * d
-                = new py::dict("pyfunc"_a = pyfunc, "pydata"_a = dataObject);
+      self._compute_arguments->GetSimulatorBufferPointer(
+        (void **) &sim_buffer);
 
-            SimBuffer * sim_buffer;
-            self.GetSimulatorBufferPointer((void **) &sim_buffer);
-            if (!sim_buffer)
-            {
-              sim_buffer = new SimBuffer;
-              self.SetSimulatorBufferPointer((void *) sim_buffer);
-            }
-            sim_buffer->callbacks.push_back(d);
+      if (!sim_buffer)
+      {
+        sim_buffer = new SimBuffer;
 
-            // select wrapper callback function
-            KIM::Function * wrap_fptr;
-            int error = false;
-            if (computeCallbackName == COMPUTE_CALLBACK_NAME::GetNeighborList)
-            { wrap_fptr = reinterpret_cast<KIM::Function *>(&get_neigh); }
-            else if (computeCallbackName
-                     == COMPUTE_CALLBACK_NAME::ProcessDEDrTerm)
-            {
-              wrap_fptr = reinterpret_cast<KIM::Function *>(&process_dEdr);
-            }
-            else if (computeCallbackName
-                     == COMPUTE_CALLBACK_NAME::ProcessD2EDr2Term)
-            {
-              wrap_fptr = reinterpret_cast<KIM::Function *>(&process_d2Edr2);
-            }
-            else
-            {
-              error = true;
-            }
+        self._compute_arguments->SetSimulatorBufferPointer(
+          (void *) sim_buffer);
+      }
 
-            // register callback to kim api
-            error = error || 
-              self.SetCallbackPointer(computeCallbackName,
-                                      LANGUAGE_NAME::cpp,
-                                      wrap_fptr,
-                                      reinterpret_cast<void * const>(d));
+      sim_buffer->callbacks.push_back(pydict);
 
-            return error;
-          },
-          py::arg("ComputeCallbackName"),
-          py::arg("callback_fn"),
-          py::arg("dataObject"))
+      // select wrapper callback function
+      KIM::Function *wrap_fptr;
 
+      if (compute_callback_name == COMPUTE_CALLBACK_NAME::GetNeighborList)
+      {
+        wrap_fptr = reinterpret_cast<KIM::Function *>(&get_neigh);
+      }
+      else if (compute_callback_name == COMPUTE_CALLBACK_NAME::ProcessDEDrTerm)
+      {
+        wrap_fptr = reinterpret_cast<KIM::Function *>(&process_dEdr);
+      }
+      else if (
+        compute_callback_name == COMPUTE_CALLBACK_NAME::ProcessD2EDr2Term)
+      {
+        wrap_fptr = reinterpret_cast<KIM::Function *>(&process_d2Edr2);
+      }
+      else
+      {
+        throw std::runtime_error("compute_callback_name is unknown!");
+      }
 
-      .def("are_all_required_arguments_and_callbacks_present",
-           [](ComputeArguments & self) {
-             int result;
-             self.AreAllRequiredArgumentsAndCallbacksPresent(&result);
-             return result;
-           })
+      // register callback to kim api
+      int error =
+        self._compute_arguments->SetCallbackPointer(
+          compute_callback_name, LANGUAGE_NAME::cpp, wrap_fptr,
+          reinterpret_cast<void *const>(pydict));
+      if (error == 1) {
+        throw std::runtime_error(
+          "fptr is not NULL and compute_callback_name is notSupported!");
+      }
+    }, "Set the function pointer for a compute_callback_name.",
+       py::arg("compute_callback_name"),
+       py::arg("callback_fn"),
+       py::arg("data_object"))
+    .def("are_all_required_arguments_and_callbacks_present",
+         [](PyComputeArguments &self) {
+      int result;
 
-      .def("__repr__", &ComputeArguments::ToString)
+      self._compute_arguments->AreAllRequiredArgumentsAndCallbacksPresent(
+        &result);
 
-      .def("set_log_id", &ComputeArguments::SetLogID)
-
-      .def("push_log_verbosity", &ComputeArguments::PushLogVerbosity)
-
-      .def("pop_log_verbosity", &ComputeArguments::PopLogVerbosity);
+      return result;
+    }, "Determine if non-NULL pointers have been set for all "
+       "compute_argument_name's and compute_callback_name's with "
+       "support_status values of requiredByAPI or required.",
+       "Return result")
+    .def("__repr__", [](PyComputeArguments &self) {
+      return self._compute_arguments->ToString();
+    }, "Get a string representing the internal state of the "
+       "compute_arguments object")
+    .def("set_log_id",
+         [](PyComputeArguments &self, std::string const &log_id) {
+      self._compute_arguments->SetLogID(log_id);
+    }, "Set the identity of the Log object associated with the "
+       "compute_arguments object.",
+       py::arg("log_id"))
+    .def("push_log_verbosity",
+         [](PyComputeArguments &self, LogVerbosity const &log_verbosity) {
+      self._compute_arguments->PushLogVerbosity(log_verbosity);
+    }, "Push a new log_verbosity onto the compute_arguments object's Log "
+       "object verbosity stack.",
+       py::arg("log_verbosity"))
+    .def("pop_log_verbosity", [](PyComputeArguments &self) {
+      self._compute_arguments->PopLogVerbosity();
+    }, "Pop a log_verbosity from the compute_arguments object's Log object "
+       "verbosity stack.");
 }

--- a/kimpy/KIM_Log_bind.cpp
+++ b/kimpy/KIM_Log_bind.cpp
@@ -85,6 +85,6 @@ PYBIND11_MODULE(log, module)
      Create a new KIM-API Log object.
 
      Returns:
-          log
+          Log: log
      )pbdoc");
 }

--- a/kimpy/KIM_Log_bind.cpp
+++ b/kimpy/KIM_Log_bind.cpp
@@ -11,80 +11,93 @@ namespace py = pybind11;
 using namespace KIM;
 
 
-namespace{
-struct PyLogDestroy {
-  void operator()(Log *log) const {
-    Log::Destroy(&log);
-  }
+namespace
+{
+struct PyLogDestroy
+{
+  void operator()(Log * log) const { Log::Destroy(&log); }
 };
-} // namespace
+}  // namespace
 
 
 PYBIND11_MODULE(log, module)
 {
   module.doc() = "Python binding to KIM_Log.hpp";
 
-  py::class_<Log, std::unique_ptr<Log, PyLogDestroy>> cl(module, "Log");
+  py::class_<Log, std::unique_ptr<Log, PyLogDestroy> > cl(module, "Log");
 
   // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([]() {
-      Log *log;
+      Log * log;
       Log::Create(&log);
       return std::unique_ptr<Log, PyLogDestroy>(std::move(log));
     }))
-    .def("push_default_verbosity", &Log::PushDefaultVerbosity,
-         "Push a new default log_verbosity onto the KIM-API "
-         "global default verbosity stack.")
-    .def("pop_default_verbosity", &Log::PopDefaultVerbosity,
-         "Pop a log_verbosity from the KIM-API global default "
-         "verbosity stack.")
-    .def("get_id", &Log::GetID, "Get the identity of the Log object.")
-    .def("set_id", &Log::SetID, "Set the identity of the Log object.",
-         py::arg("id"))
-    .def("push_verbosity", &Log::PushVerbosity,
-         "Push a new log_verbosity onto the Log object's verbosity stack.",
-         py::arg("log_verbosity"))
-    .def("pop_verbosity", &Log::PopVerbosity,
-         "Pop a log_verbosity from the Log object's verbosity stack.")
-    // cannot simply do wrapping for the following overloaded functions as for
-    // set_parameters in KIM_Model.hpp, because here the first argument is a
-    // self-defined class. If we do that, pybind11 will report argument type
-    // matching error.
-    .def("log_entry",
-         [](Log &self,
-            LogVerbosity const &log_verbosity,
-            std::string const &message,
-            int const line_number,
-            std::string const &file_name) {
-       self.LogEntry(log_verbosity, message, line_number, file_name);
-     }, "Write a log entry into the log file.",
-        py::arg("log_verbosity"),
-        py::arg("message"),
-        py::arg("line_number"),
-        py::arg("file_name"))
-    .def("log_entry",
-         [](Log &self,
-            LogVerbosity const &log_verbosity,
-            std::stringstream const &message,
-            int const line_number,
-            std::string const &file_name) {
-      self.LogEntry(log_verbosity, message, line_number, file_name);
-    }, "Write a log entry into the log file.",
-       py::arg("log_verbosity"),
-       py::arg("message"),
-       py::arg("line_number"),
-       py::arg("file_name"));
+      .def("push_default_verbosity",
+           &Log::PushDefaultVerbosity,
+           "Push a new default log_verbosity onto the KIM-API "
+           "global default verbosity stack.")
+      .def("pop_default_verbosity",
+           &Log::PopDefaultVerbosity,
+           "Pop a log_verbosity from the KIM-API global default "
+           "verbosity stack.")
+      .def("get_id", &Log::GetID, "Get the identity of the Log object.")
+      .def("set_id",
+           &Log::SetID,
+           "Set the identity of the Log object.",
+           py::arg("id"))
+      .def("push_verbosity",
+           &Log::PushVerbosity,
+           "Push a new log_verbosity onto the Log object's verbosity stack.",
+           py::arg("log_verbosity"))
+      .def("pop_verbosity",
+           &Log::PopVerbosity,
+           "Pop a log_verbosity from the Log object's verbosity stack.")
+      // cannot simply do wrapping for the following overloaded functions as for
+      // set_parameters in KIM_Model.hpp, because here the first argument is a
+      // self-defined class. If we do that, pybind11 will report argument type
+      // matching error.
+      .def(
+          "log_entry",
+          [](Log & self,
+             LogVerbosity const & log_verbosity,
+             std::string const & message,
+             int const line_number,
+             std::string const & file_name) {
+            self.LogEntry(log_verbosity, message, line_number, file_name);
+          },
+          "Write a log entry into the log file.",
+          py::arg("log_verbosity"),
+          py::arg("message"),
+          py::arg("line_number"),
+          py::arg("file_name"))
+      .def(
+          "log_entry",
+          [](Log & self,
+             LogVerbosity const & log_verbosity,
+             std::stringstream const & message,
+             int const line_number,
+             std::string const & file_name) {
+            self.LogEntry(log_verbosity, message, line_number, file_name);
+          },
+          "Write a log entry into the log file.",
+          py::arg("log_verbosity"),
+          py::arg("message"),
+          py::arg("line_number"),
+          py::arg("file_name"));
 
   // module functions
 
-  module.def("create", []() {
-    Log *log;
+  module.def(
+      "create",
+      []() {
+    Log * log;
     Log::Create(&log);
     return std::unique_ptr<Log, PyLogDestroy>(std::move(log));
-  }, R"pbdoc(
-     Create a new KIM-API Log object.
+      }, R"pbdoc(
+         Create a new KIM-API Log object.
 
-     Returns:
-          Log: log
-     )pbdoc");
+         Returns:
+            Log: log
+         )pbdoc"
+      );
 }

--- a/kimpy/KIM_Log_bind.cpp
+++ b/kimpy/KIM_Log_bind.cpp
@@ -1,7 +1,7 @@
 
 #include <pybind11/pybind11.h>
 
-#include <memory> 
+#include <memory>
 #include <string>
 
 #include "KIM_Log.hpp"
@@ -10,6 +10,11 @@
 namespace py = pybind11;
 using namespace KIM;
 
+struct PyLogDestroy {
+  void operator()(Log *log) const {
+    Log::Destroy(&log);
+  }
+};
 
 PYBIND11_MODULE(log, module)
 {
@@ -23,7 +28,7 @@ PYBIND11_MODULE(log, module)
   // destroy function from the C++ side to avoid memory leaks. For more info,
   // see http://pybind11.readthedocs.io/en/stable/advanced/classes.html
 
-  py::class_<Log, std::unique_ptr<Log, py::nodelete> > cl(module, "Log");
+  py::class_<Log, std::unique_ptr<Log, PyLogDestroy> > cl(module, "Log");
 
   // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([]() {

--- a/kimpy/KIM_Log_bind.cpp
+++ b/kimpy/KIM_Log_bind.cpp
@@ -10,84 +10,77 @@
 namespace py = pybind11;
 using namespace KIM;
 
+
+namespace{
 struct PyLogDestroy {
   void operator()(Log *log) const {
     Log::Destroy(&log);
   }
 };
+} // namespace
+
 
 PYBIND11_MODULE(log, module)
 {
   module.doc() = "Python binding to KIM_Log.hpp";
 
-  // C++ class constructor and destructor are private, which can not be wrapped
-  // directly.
-  // So we need to call the C++ class factory function in py::init, and use
-  // `py::nodelete` to avoid calling the destructor when python instance is
-  // destroyed. It is crucial that the instance is deallocated by calling the
-  // destroy function from the C++ side to avoid memory leaks. For more info,
-  // see http://pybind11.readthedocs.io/en/stable/advanced/classes.html
-
-  py::class_<Log, std::unique_ptr<Log, PyLogDestroy> > cl(module, "Log");
+  py::class_<Log, std::unique_ptr<Log, PyLogDestroy>> cl(module, "Log");
 
   // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([]() {
-      Log * log;
+      Log *log;
       Log::Create(&log);
-      return log;
+      return std::unique_ptr<Log, PyLogDestroy>(std::move(log));
     }))
-
-
-      .def("pop_default_verbosity", &Log::PopDefaultVerbosity)
-
-      .def("get_id", &Log::GetID)
-
-      .def("set_id", &Log::SetID)
-
-      .def("push_verbosity", &Log::PushVerbosity)
-
-      .def("pop_verbosity", &Log::PopVerbosity)
-
-      // cannot simply do wrapping for the following overloaded functions as for
-      // set_parameters in KIM_Model.hpp, because here the first argument is a
-      // self-defined class. If we do that, pybind11 will report argument type
-      // matching error.
-      .def(
-          "log_entry",
-          [](Log & self,
-             LogVerbosity const logVerbosity,
-             std::string const & message,
-             int const lineNumber,
-             std::string const & fileName) {
-            self.LogEntry(logVerbosity, message, lineNumber, fileName);
-          },
-          py::arg("logVerbosity"),
-          py::arg("message"),
-          py::arg("lineNumber"),
-          py::arg("fileNmae"))
-
-      .def(
-          "log_entry",
-          [](Log & self,
-             LogVerbosity const logVerbosity,
-             std::stringstream const & message,
-             int const lineNumber,
-             std::string const & fileName) {
-            self.LogEntry(logVerbosity, message, lineNumber, fileName);
-          },
-          py::arg("logVerbosity"),
-          py::arg("message"),
-          py::arg("lineNumber"),
-          py::arg("fileNmae"));
-
+    .def("push_default_verbosity", &Log::PushDefaultVerbosity,
+         "Push a new default log_verbosity onto the KIM-API "
+         "global default verbosity stack.")
+    .def("pop_default_verbosity", &Log::PopDefaultVerbosity,
+         "Pop a log_verbosity from the KIM-API global default "
+         "verbosity stack.")
+    .def("get_id", &Log::GetID, "Get the identity of the Log object.")
+    .def("set_id", &Log::SetID, "Set the identity of the Log object.",
+         py::arg("id"))
+    .def("push_verbosity", &Log::PushVerbosity,
+         "Push a new log_verbosity onto the Log object's verbosity stack.",
+         py::arg("log_verbosity"))
+    .def("pop_verbosity", &Log::PopVerbosity,
+         "Pop a log_verbosity from the Log object's verbosity stack.")
+    // cannot simply do wrapping for the following overloaded functions as for
+    // set_parameters in KIM_Model.hpp, because here the first argument is a
+    // self-defined class. If we do that, pybind11 will report argument type
+    // matching error.
+    .def("log_entry",
+         [](Log &self,
+            LogVerbosity const &log_verbosity,
+            std::string const &message,
+            int const line_number,
+            std::string const &file_name) {
+       self.LogEntry(log_verbosity, message, line_number, file_name);
+     }, "Write a log entry into the log file.",
+        py::arg("log_verbosity"),
+        py::arg("message"),
+        py::arg("line_number"),
+        py::arg("file_name"))
+    .def("log_entry",
+         [](Log &self,
+            LogVerbosity const &log_verbosity,
+            std::stringstream const &message,
+            int const line_number,
+            std::string const &file_name) {
+      self.LogEntry(log_verbosity, message, line_number, file_name);
+    }, "Write a log entry into the log file.",
+       py::arg("log_verbosity"),
+       py::arg("message"),
+       py::arg("line_number"),
+       py::arg("file_name"));
 
   // module functions
 
   module.def("create", []() {
-    Log * log;
+    Log *log;
     Log::Create(&log);
-    return log;
-  });
-
-  module.def("destroy", [](Log * self) { Log::Destroy(&self); });
+    return std::unique_ptr<Log, PyLogDestroy>(std::move(log));
+  }, "Create a new KIM-API Log object."
+     "Return log");
 }

--- a/kimpy/KIM_Log_bind.cpp
+++ b/kimpy/KIM_Log_bind.cpp
@@ -81,6 +81,10 @@ PYBIND11_MODULE(log, module)
     Log *log;
     Log::Create(&log);
     return std::unique_ptr<Log, PyLogDestroy>(std::move(log));
-  }, "Create a new KIM-API Log object."
-     "Return log");
+  }, R"pbdoc(
+     Create a new KIM-API Log object.
+
+     Returns:
+          log
+     )pbdoc");
 }

--- a/kimpy/KIM_Model_bind.cpp
+++ b/kimpy/KIM_Model_bind.cpp
@@ -63,18 +63,25 @@ PYBIND11_MODULE(model, module)
       re[0] = present;
       re[1] = required;
       return re;
-    }, "Determine presence and required status of the given "
-       "model_routine_name.",
-       py::arg("model_routine_name"),
-       "Return(present, required)")
+    }, R"pbdoc(
+       Determine presence and required status of the given model_routine_name.
+
+       Returns:
+           int, int: present, required
+       )pbdoc",
+       py::arg("model_routine_name"))
     .def("get_influence_distance", [](PyModel &self) {
       double influence_distance;
 
       self._model->GetInfluenceDistance(&influence_distance);
 
       return influence_distance;
-    }, "Get the model's influence distance.",
-       "Return influence_distance")
+    }, R"pbdoc(
+       Get the model's influence distance.
+
+       Returns:
+           float: influence_distance
+       )pbdoc")
     .def("get_neighbor_list_cutoffs_and_hints", [](PyModel &self) {
       int number_of_cutoffs;
       double const *cutoff_ptr;
@@ -105,9 +112,13 @@ PYBIND11_MODULE(model, module)
       re[0] = cutoffs;
       re[1] = model_not_request_neighbors_of_noncontributing_particles;
       return re;
-    }, "Get the model's neighbor list information.",
-       "Return(cutoffs, "
-       "model_not_request_neighbors_of_noncontributing_particles)")
+    }, R"pbdoc(
+       Get the model's neighbor list information.
+
+       Returns:
+           1darray, 1darray: cutoffs,
+               model_not_request_neighbors_of_noncontributing_particles
+       )pbdoc")
     .def("get_units", [](PyModel &self) {
       LengthUnit length_unit;
       EnergyUnit energy_unit;
@@ -128,9 +139,12 @@ PYBIND11_MODULE(model, module)
       re[3] = temperature_unit;
       re[4] = time_unit;
       return re;
-    }, "Get the model's base unit values.",
-       "Return(length_unit, energy_unit, charge_unit, "
-       "temperature_unit, time_unit)")
+    }, R"pbdoc(
+       Get the model's base unit values.
+
+       Returns:
+           length_unit, energy_unit, charge_unit, temperature_unit, time_unit
+       )pbdoc")
     .def("compute_arguments_create", [](std::shared_ptr<PyModel> self) {
       std::shared_ptr<PyComputeArguments>
         py_compute_arguments(new PyComputeArguments(self));
@@ -144,8 +158,12 @@ PYBIND11_MODULE(model, module)
       }
 
       return py_compute_arguments;
-    }, "Create a new compute_arguments object for the model object.",
-       "Return compute_arguments")
+    }, R"pbdoc(
+       Create a new compute_arguments object for the model object.
+
+       Returns:
+           compute_arguments
+       )pbdoc")
     .def("compute",
          [](PyModel &self,
             std::shared_ptr<PyComputeArguments> compute_arguments,
@@ -205,17 +223,25 @@ PYBIND11_MODULE(model, module)
       re[0] = species_is_supported;
       re[1] = code;
       return re;
-    }, "Get the model's support and code for the requested species_name.",
-       py::arg("species_name"),
-       "Return(species_is_supported, code)")
+    }, R"pbdoc(
+       Get the model's support and code for the requested species_name.
+
+       Returns:
+           int, int: species_is_supported, code
+       )pbdoc",
+       py::arg("species_name"))
     .def("get_number_of_parameters", [](PyModel &self) {
       int number_pf_parameters;
 
       self._model->GetNumberOfParameters(&number_pf_parameters);
 
       return number_pf_parameters;
-    }, "Get the number of parameter arrays provided by the model.",
-       "Return number_pf_parameters")
+    }, R"pbdoc(
+       Get the number of parameter arrays provided by the model.
+
+       Returns:
+           int: number_pf_parameters
+       )pbdoc")
     .def("get_parameter_metadata",
          [](PyModel &self, int const parameter_index) {
       DataType data_type;
@@ -235,10 +261,13 @@ PYBIND11_MODULE(model, module)
       re[2] = *name;
       re[3] = *description;
       return re;
-    }, "Get the metadata associated with one of the "
-       "models's parameter arrays.",
-       py::arg("parameterIndex"),
-       "Return(data_type, extent, name, description)")
+    }, R"pbdoc(
+       Get the metadata associated with one of the models's parameter arrays.
+
+       Returns:
+           data_type, int, str, str: data_type, extent, name, description
+       )pbdoc",
+       py::arg("parameterIndex"))
     .def("get_parameter_int",
          [](PyModel &self, int const parameter_index, int const array_index) {
       int parameter_value;
@@ -255,10 +284,14 @@ PYBIND11_MODULE(model, module)
       }
 
       return parameter_value;
-    }, "Get an int parameter value from the Model.",
+    }, R"pbdoc(
+       Get an int parameter value from the Model.
+
+       Returns:
+           int: parameter_value
+       )pbdoc",
        py::arg("parameter_index"),
-       py::arg("array_index"),
-       "Return parameter_value")
+       py::arg("array_index"))
     .def("get_parameter_double",
          [](PyModel &self, int const parameter_index, int const array_index) {
       double parameter_value;
@@ -275,10 +308,14 @@ PYBIND11_MODULE(model, module)
       }
 
       return parameter_value;
-    }, "Get a double parameter value from the Model.",
+    }, R"pbdoc(
+       Get a double parameter value from the Model.
+
+       Returns:
+           float: parameter_value
+       )pbdoc",
        py::arg("parameter_index"),
-       py::arg("array_index"),
-       "Return parameter_value")
+       py::arg("array_index"))
     // overloaded function
     .def("set_parameter",
           [](PyModel &self,
@@ -369,13 +406,17 @@ PYBIND11_MODULE(model, module)
     re[0] = requested_units_accepted;
     re[1] = model;
     return re;
-  }, "Create a new KIM-API model object.",
+  }, R"pbdoc(
+     Create a new KIM-API model object.
+
+     Returns:
+         int, model: requested_units_accepted, model
+     )pbdoc",
      py::arg("numbering"),
      py::arg("requested_length_unit"),
      py::arg("requested_energy_unit"),
      py::arg("requested_charge_unit"),
      py::arg("requested_temperature_unit"),
      py::arg("requested_time_unit"),
-     py::arg("model_name"),
-     "Return(requested_units_accepted, model)");
+     py::arg("model_name"));
 }

--- a/kimpy/KIM_Model_bind.cpp
+++ b/kimpy/KIM_Model_bind.cpp
@@ -5,8 +5,8 @@
 #include <string>
 
 #include "KIM_SimulatorHeaders.hpp"
-#include "sim_buffer.h"
 #include "py_kim_wrapper.h"
+#include "sim_buffer.h"
 
 namespace py = pybind11;
 using namespace KIM;
@@ -16,8 +16,9 @@ PYBIND11_MODULE(model, module)
 {
   module.doc() = "Python binding to KIM_Model.hpp";
 
-  py::class_<PyModel, std::shared_ptr<PyModel>> cl(module, "PyModel");
+  py::class_<PyModel, std::shared_ptr<PyModel> > cl(module, "PyModel");
 
+  // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([](Numbering const &numbering,
                      LengthUnit const &requested_length_unit,
                      EnergyUnit const &requested_energy_unit,
@@ -26,43 +27,44 @@ PYBIND11_MODULE(model, module)
                      TimeUnit const &requested_time_unit,
                      std::string const &model_name,
                      py::array_t<int> requested_units_accepted) {
-      int *kim_requested_units_accepted =
-        requested_units_accepted.mutable_data(0);
+    int * kim_requested_units_accepted
+        = requested_units_accepted.mutable_data(0);
 
-      std::shared_ptr<PyModel> model(new PyModel());
+    std::shared_ptr<PyModel> model(new PyModel());
 
-      int error = Model::Create(numbering,
-                                requested_length_unit,
-                                requested_energy_unit,
-                                requested_charge_unit,
-                                requested_temperature_unit,
-                                requested_time_unit,
-                                model_name,
-                                kim_requested_units_accepted,
-                                &model->_model);
-      if (error == 1) {
-        throw std::runtime_error(
-          "Unable to create a new KIM-API model object!");
-      }
+    int error = Model::Create(numbering,
+                              requested_length_unit,
+                              requested_energy_unit,
+                              requested_charge_unit,
+                              requested_temperature_unit,
+                              requested_time_unit,
+                              model_name,
+                              kim_requested_units_accepted,
+                              &model->_model);
+    if (error == 1)
+    {
+      throw std::runtime_error("Unable to create a new KIM-API Model object!");
+    }
 
-      return model;
+    return model;
     }))
     .def("is_routine_present",
          [](PyModel &self, ModelRoutineName const &model_routine_name) {
-      int present;
-      int required;
+    int present;
+    int required;
 
-      int error =
-        self._model->IsRoutinePresent(model_routine_name, &present, &required);
-      if (error == 1) {
-        throw std::runtime_error("model_routine_name = " +
-          model_routine_name.ToString() + "is unknown!");
-      }
+    int error = self._model->IsRoutinePresent(
+        model_routine_name, &present, &required);
+    if (error == 1)
+    {
+      throw std::runtime_error("model_routine_name = "
+                               + model_routine_name.ToString() + "is unknown!");
+    }
 
-      py::tuple re(2);
-      re[0] = present;
-      re[1] = required;
-      return re;
+    py::tuple re(2);
+    re[0] = present;
+    re[1] = required;
+    return re;
     }, R"pbdoc(
        Determine presence and required status of the given model_routine_name.
 
@@ -71,11 +73,11 @@ PYBIND11_MODULE(model, module)
        )pbdoc",
        py::arg("model_routine_name"))
     .def("get_influence_distance", [](PyModel &self) {
-      double influence_distance;
+    double influence_distance;
 
-      self._model->GetInfluenceDistance(&influence_distance);
+    self._model->GetInfluenceDistance(&influence_distance);
 
-      return influence_distance;
+    return influence_distance;
     }, R"pbdoc(
        Get the model's influence distance.
 
@@ -83,35 +85,35 @@ PYBIND11_MODULE(model, module)
            float: influence_distance
        )pbdoc")
     .def("get_neighbor_list_cutoffs_and_hints", [](PyModel &self) {
-      int number_of_cutoffs;
-      double const *cutoff_ptr;
-      int const *kim_model_not_request_neighbors_of_noncontributing_particles;
+    int number_of_cutoffs;
+    double const * cutoff_ptr;
+    int const * kim_model_not_request_neighbors_of_noncontributing_particles;
 
-      self._model->GetNeighborListPointers(
-        &number_of_cutoffs, &cutoff_ptr,
+    self._model->GetNeighborListPointers(
+        &number_of_cutoffs,
+        &cutoff_ptr,
         &kim_model_not_request_neighbors_of_noncontributing_particles);
 
-      py::array_t<double, py::array::c_style> cutoffs(number_of_cutoffs);
-      py::array_t<int, py::array::c_style>
+    py::array_t<double, py::array::c_style> cutoffs(number_of_cutoffs);
+    py::array_t<int, py::array::c_style>
         model_not_request_neighbors_of_noncontributing_particles(
-          number_of_cutoffs);
+            number_of_cutoffs);
 
-      auto cut = cutoffs.mutable_data(0);
-      auto pnh =
-        model_not_request_neighbors_of_noncontributing_particles.mutable_data(
-          0);
+    auto cut = cutoffs.mutable_data(0);
+    auto pnh
+        = model_not_request_neighbors_of_noncontributing_particles.mutable_data(
+            0);
 
-      for (int i = 0; i < number_of_cutoffs; i++)
-      {
-        cut[i] = cutoff_ptr[i];
-        pnh[i] =
-          kim_model_not_request_neighbors_of_noncontributing_particles[i];
-      }
+    for (int i = 0; i < number_of_cutoffs; i++)
+    {
+      cut[i] = cutoff_ptr[i];
+      pnh[i] = kim_model_not_request_neighbors_of_noncontributing_particles[i];
+    }
 
-      py::tuple re(2);
-      re[0] = cutoffs;
-      re[1] = model_not_request_neighbors_of_noncontributing_particles;
-      return re;
+    py::tuple re(2);
+    re[0] = cutoffs;
+    re[1] = model_not_request_neighbors_of_noncontributing_particles;
+    return re;
     }, R"pbdoc(
        Get the model's neighbor list information.
 
@@ -120,25 +122,25 @@ PYBIND11_MODULE(model, module)
                model_not_request_neighbors_of_noncontributing_particles
        )pbdoc")
     .def("get_units", [](PyModel &self) {
-      LengthUnit length_unit;
-      EnergyUnit energy_unit;
-      ChargeUnit charge_unit;
-      TemperatureUnit temperature_unit;
-      TimeUnit time_unit;
+    LengthUnit length_unit;
+    EnergyUnit energy_unit;
+    ChargeUnit charge_unit;
+    TemperatureUnit temperature_unit;
+    TimeUnit time_unit;
 
-      self._model->GetUnits(&length_unit,
-                            &energy_unit,
-                            &charge_unit,
-                            &temperature_unit,
-                            &time_unit);
+    self._model->GetUnits(&length_unit,
+                          &energy_unit,
+                          &charge_unit,
+                          &temperature_unit,
+                          &time_unit);
 
-      py::tuple re(5);
-      re[0] = length_unit;
-      re[1] = energy_unit;
-      re[2] = charge_unit;
-      re[3] = temperature_unit;
-      re[4] = time_unit;
-      return re;
+    py::tuple re(5);
+    re[0] = length_unit;
+    re[1] = energy_unit;
+    re[2] = charge_unit;
+    re[3] = temperature_unit;
+    re[4] = time_unit;
+    return re;
     }, R"pbdoc(
        Get the model's base unit values.
 
@@ -148,18 +150,18 @@ PYBIND11_MODULE(model, module)
                time_unit
        )pbdoc")
     .def("compute_arguments_create", [](std::shared_ptr<PyModel> self) {
-      std::shared_ptr<PyComputeArguments>
-        py_compute_arguments(new PyComputeArguments(self));
+    std::shared_ptr<PyComputeArguments> py_compute_arguments(
+        new PyComputeArguments(self));
 
-      int error = self->_model->ComputeArgumentsCreate(
+    int error = self->_model->ComputeArgumentsCreate(
         &py_compute_arguments->_compute_arguments);
-      if (error == 1) {
-        throw std::runtime_error(
-          "Unable to create a new compute_arguments "
-          "object for the model object!");
-      }
+    if (error == 1)
+    {
+      throw std::runtime_error("Unable to create a new compute_arguments "
+                               "object for the model object!");
+    }
 
-      return py_compute_arguments;
+    return py_compute_arguments;
     }, R"pbdoc(
        Create a new compute_arguments object for the model object.
 
@@ -170,61 +172,64 @@ PYBIND11_MODULE(model, module)
          [](PyModel &self,
             std::shared_ptr<PyComputeArguments> compute_arguments,
             bool release_GIL) {
-      ComputeArguments const *const kim_compute_arguments =
-        compute_arguments->_compute_arguments;
+    ComputeArguments const * const kim_compute_arguments
+        = compute_arguments->_compute_arguments;
 
-      int error;
-      if (release_GIL)
-      {
-        py::gil_scoped_release release;
-        error = self._model->Compute(kim_compute_arguments);
-      }
-      else
-      {
-        error = self._model->Compute(kim_compute_arguments);
-      }
-      if (error == 1) {
-        throw std::runtime_error(
+    int error;
+    if (release_GIL)
+    {
+      py::gil_scoped_release release;
+      error = self._model->Compute(kim_compute_arguments);
+    }
+    else
+    {
+      error = self._model->Compute(kim_compute_arguments);
+    }
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "the model does not provide an Extension routine!  or\n"
           "the model's Extension routine returns error!");
-      }
+    }
     }, "Call the model's Compute routine.",
        py::arg("compute_arguments"),
        py::arg("release_GIL") = false)
     .def("clear_then_refresh", [](PyModel &self) {
-      self._model->ClearThenRefresh();
+    self._model->ClearThenRefresh();
     }, "Clear influence distance and neighbor list pointers and refresh "
        "model object after parameter changes.")
     .def("write_parameterized_model",
          [](PyModel &self,
             std::string const &path,
             std::string const &model_name) {
-      int error = self._model->WriteParameterizedModel(path, model_name);
-      if (error == 1) {
-        throw std::runtime_error(
+    int error = self._model->WriteParameterizedModel(path, model_name);
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "the model object is not a parameterized model!  or\n"
           "the model_name is not a valid C identifier!  or\n"
           "the model's WriteParameterizedModel routine returns error!");
-      }
+    }
     }, "Call the model's WriteParameterizedModel routine.",
        py::arg("path"),
        py::arg("model_name"))
     .def("get_species_support_and_code",
          [](PyModel &self, SpeciesName const &species_name) {
-      int species_is_supported;
-      int code = -1;
+    int species_is_supported;
+    int code = -1;
 
-      int error = self._model->GetSpeciesSupportAndCode(
+    int error = self._model->GetSpeciesSupportAndCode(
         species_name, &species_is_supported, &code);
-      if (error == 1) {
-        throw std::runtime_error("species_name = " +
-          species_name.ToString() + " is unknown!");
-      }
+    if (error == 1)
+    {
+      throw std::runtime_error("species_name = " + species_name.ToString()
+                               + " is unknown!");
+    }
 
-      py::tuple re(2);
-      re[0] = species_is_supported;
-      re[1] = code;
-      return re;
+    py::tuple re(2);
+    re[0] = species_is_supported;
+    re[1] = code;
+    return re;
     }, R"pbdoc(
        Get the model's support and code for the requested species_name.
 
@@ -233,11 +238,11 @@ PYBIND11_MODULE(model, module)
        )pbdoc",
        py::arg("species_name"))
     .def("get_number_of_parameters", [](PyModel &self) {
-      int number_pf_parameters;
+    int number_pf_parameters;
 
-      self._model->GetNumberOfParameters(&number_pf_parameters);
+    self._model->GetNumberOfParameters(&number_pf_parameters);
 
-      return number_pf_parameters;
+    return number_pf_parameters;
     }, R"pbdoc(
        Get the number of parameter arrays provided by the model.
 
@@ -246,23 +251,21 @@ PYBIND11_MODULE(model, module)
        )pbdoc")
     .def("get_parameter_metadata",
          [](PyModel &self, int const parameter_index) {
-      DataType data_type;
-      int extent;
-      std::string const *name;
-      std::string const *description;
+    DataType data_type;
+    int extent;
+    std::string const * name;
+    std::string const * description;
 
-      int error = self._model->GetParameterMetadata(
+    int error = self._model->GetParameterMetadata(
         parameter_index, &data_type, &extent, &name, &description);
-      if (error == 1) {
-        throw std::runtime_error("parameter_index is invalid!");
-      }
+    if (error == 1) { throw std::runtime_error("parameter_index is invalid!"); }
 
-      py::tuple re(4);
-      re[0] = data_type;
-      re[1] = extent;
-      re[2] = *name;
-      re[3] = *description;
-      return re;
+    py::tuple re(4);
+    re[0] = data_type;
+    re[1] = extent;
+    re[2] = *name;
+    re[3] = *description;
+    return re;
     }, R"pbdoc(
        Get the metadata associated with one of the models's parameter arrays.
 
@@ -272,20 +275,21 @@ PYBIND11_MODULE(model, module)
        py::arg("parameterIndex"))
     .def("get_parameter_int",
          [](PyModel &self, int const parameter_index, int const array_index) {
-      int parameter_value;
+    int parameter_value;
 
-      int error =
-        self._model->GetParameter(
-          parameter_index, array_index, &parameter_value);
-      if (error == 1) {
-        throw std::runtime_error(
-          "parameter_index = " + std::to_string(parameter_index) +
-          " is invalid!  or\nthe specified parameter "
-          "and parameter_value are of different data types!  or\n"
-          "array_index = " + std::to_string(array_index) + "is invalid!");
-      }
+    int error = self._model->GetParameter(
+        parameter_index, array_index, &parameter_value);
+    if (error == 1)
+    {
+      throw std::runtime_error(
+          "parameter_index = " + std::to_string(parameter_index)
+          + " is invalid!  or\nthe specified parameter "
+            "and parameter_value are of different data types!  or\n"
+            "array_index = "
+          + std::to_string(array_index) + "is invalid!");
+    }
 
-      return parameter_value;
+    return parameter_value;
     }, R"pbdoc(
        Get an int parameter value from the Model.
 
@@ -296,20 +300,21 @@ PYBIND11_MODULE(model, module)
        py::arg("array_index"))
     .def("get_parameter_double",
          [](PyModel &self, int const parameter_index, int const array_index) {
-      double parameter_value;
+    double parameter_value;
 
-      int error =
-        self._model->GetParameter(
-          parameter_index, array_index, &parameter_value);
-      if (error == 1) {
-        throw std::runtime_error(
-          "parameter_index = " + std::to_string(parameter_index) +
-          " is invalid!  or\nthe specified parameter "
-          "and parameter_value are of different data types!  or\n"
-          "array_index = " + std::to_string(array_index) + " is invalid!");
-      }
+    int error = self._model->GetParameter(
+        parameter_index, array_index, &parameter_value);
+    if (error == 1)
+    {
+      throw std::runtime_error(
+          "parameter_index = " + std::to_string(parameter_index)
+          + " is invalid!  or\nthe specified parameter "
+            "and parameter_value are of different data types!  or\n"
+            "array_index = "
+          + std::to_string(array_index) + " is invalid!");
+    }
 
-      return parameter_value;
+    return parameter_value;
     }, R"pbdoc(
        Get a double parameter value from the Model.
 
@@ -324,16 +329,17 @@ PYBIND11_MODULE(model, module)
              int const parameter_index,
              int const array_index,
              int const parameter_value) {
-      int error =
-        self._model->SetParameter(
-          parameter_index, array_index, parameter_value);
-      if (error == 1) {
-        throw std::runtime_error(
-          "parameter_index = " + std::to_string(parameter_index) +
-          " is invalid!  or\nthe specified parameter "
-          "and parameter_value are of different data types!  or\n"
-          "array_index = " + std::to_string(array_index) + " is invalid!");
-      }
+    int error = self._model->SetParameter(
+        parameter_index, array_index, parameter_value);
+    if (error == 1)
+    {
+      throw std::runtime_error(
+          "parameter_index = " + std::to_string(parameter_index)
+          + " is invalid!  or\nthe specified parameter "
+            "and parameter_value are of different data types!  or\n"
+            "array_index = "
+          + std::to_string(array_index) + " is invalid!");
+    }
     }, "Set an int parameter value for the Model.",
        py::arg("parameter_index"),
        py::arg("array_index"),
@@ -343,36 +349,37 @@ PYBIND11_MODULE(model, module)
              int const parameter_index,
              int const array_index,
              double const parameter_value) {
-      int error =
-        self._model->SetParameter(
-          parameter_index, array_index, parameter_value);
-      if (error == 1) {
-        throw std::runtime_error(
-          "parameter_index = " + std::to_string(parameter_index) +
-          " is invalid!  or\nthe specified parameter "
-          "and parameter_value are of different data types!  or\n"
-          "array_index = " + std::to_string(array_index) + " is invalid!");
-      }
+    int error = self._model->SetParameter(
+        parameter_index, array_index, parameter_value);
+    if (error == 1)
+    {
+      throw std::runtime_error(
+          "parameter_index = " + std::to_string(parameter_index)
+          + " is invalid!  or\nthe specified parameter "
+            "and parameter_value are of different data types!  or\n"
+            "array_index = "
+          + std::to_string(array_index) + " is invalid!");
+    }
     }, "Set an int parameter value for the Model.",
        py::arg("parameter_index"),
        py::arg("array_index"),
        py::arg("parameter_value"))
     .def("__repr__", [](PyModel &self) {
-      return self._model->ToString();
+    return self._model->ToString();
     },"A string representing the internal state of the model object.")
     .def("set_log_id", [](PyModel &self, std::string const &log_id) {
-      self._model->SetLogID(log_id);
+    self._model->SetLogID(log_id);
     }, "Set the identity of the Log object associated "
        "with the model object.",
        py::arg("log_id"))
     .def("push_log_verbosity",
          [](PyModel &self, LogVerbosity const &log_verbosity) {
-      self._model->PushLogVerbosity(log_verbosity);
+    self._model->PushLogVerbosity(log_verbosity);
     }, "Push a new LogVerbosity onto the Model object's Log object "
        "verbosity stack.",
        py::arg("log_verbosity"))
     .def("pop_log_verbosity", [](PyModel &self) {
-      self._model->PopLogVerbosity();
+    self._model->PopLogVerbosity();
     }, "Pop a LogVerbosity from the Model object's Log object "
        "verbosity stack.");
 
@@ -399,9 +406,9 @@ PYBIND11_MODULE(model, module)
                               model_name,
                               &requested_units_accepted,
                               &model->_model);
-    if (error == 1) {
-      throw std::runtime_error(
-        "Unable to create a new KIM-API model object!");
+    if (error == 1)
+    {
+      throw std::runtime_error("Unable to create a new KIM-API Model object!");
     }
 
     py::tuple re(2);
@@ -409,7 +416,7 @@ PYBIND11_MODULE(model, module)
     re[1] = model;
     return re;
   }, R"pbdoc(
-     Create a new KIM-API model object.
+     Create a new KIM-API Model object.
 
      Returns:
          int, Model: requested_units_accepted, model

--- a/kimpy/KIM_Model_bind.cpp
+++ b/kimpy/KIM_Model_bind.cpp
@@ -11,6 +11,11 @@
 namespace py = pybind11;
 using namespace KIM;
 
+struct PyModelDestroy {
+  void operator()(Model *model) const {
+    Model::Destroy(&model);
+  }
+};
 
 PYBIND11_MODULE(model, module)
 {
@@ -24,7 +29,7 @@ PYBIND11_MODULE(model, module)
   // destroy function from the C++ side to avoid memory leaks. For more info,
   // see http://pybind11.readthedocs.io/en/stable/advanced/classes.html
 
-  py::class_<Model, std::unique_ptr<Model, py::nodelete> > cl(module, "Model");
+  py::class_<Model, std::unique_ptr<Model, PyModelDestroy>> cl(module, "Model");
 
   // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([](Numbering const numbering,
@@ -88,9 +93,9 @@ PYBIND11_MODULE(model, module)
                 &numberOfCutoffs, &cutoff_ptr, &paddingNoNeighborHints_ptr);
 
             py::array_t<double, py::array::c_style> cutoffs(numberOfCutoffs);
-            py::array_t<int, py::array::c_style> 
+            py::array_t<int, py::array::c_style>
               paddingNoNeighborHints(numberOfCutoffs);
-            
+
             auto cut = cutoffs.mutable_data(0);
             auto pnh = paddingNoNeighborHints.mutable_data(0);
             for (int i = 0; i < numberOfCutoffs; i++)
@@ -152,7 +157,7 @@ PYBIND11_MODULE(model, module)
             if (sim_buffer)
             {
               for (std::size_t i = 0; i < sim_buffer->callbacks.size(); i++)
-              { 
+              {
                 if (sim_buffer->callbacks[i]) delete sim_buffer->callbacks[i];
               }
               delete sim_buffer;

--- a/kimpy/KIM_Model_bind.cpp
+++ b/kimpy/KIM_Model_bind.cpp
@@ -143,7 +143,9 @@ PYBIND11_MODULE(model, module)
        Get the model's base unit values.
 
        Returns:
-           length_unit, energy_unit, charge_unit, temperature_unit, time_unit
+           LengthUnit, EnergyUnit, ChargeUnit, TemperatureUnit, TimeUnit:
+               length_unit, energy_unit, charge_unit, temperature_unit,
+               time_unit
        )pbdoc")
     .def("compute_arguments_create", [](std::shared_ptr<PyModel> self) {
       std::shared_ptr<PyComputeArguments>
@@ -162,7 +164,7 @@ PYBIND11_MODULE(model, module)
        Create a new compute_arguments object for the model object.
 
        Returns:
-           compute_arguments
+           ComputeArguments: compute_arguments
        )pbdoc")
     .def("compute",
          [](PyModel &self,
@@ -265,7 +267,7 @@ PYBIND11_MODULE(model, module)
        Get the metadata associated with one of the models's parameter arrays.
 
        Returns:
-           data_type, int, str, str: data_type, extent, name, description
+           DataType, int, str, str: data_type, extent, name, description
        )pbdoc",
        py::arg("parameterIndex"))
     .def("get_parameter_int",
@@ -410,7 +412,7 @@ PYBIND11_MODULE(model, module)
      Create a new KIM-API model object.
 
      Returns:
-         int, model: requested_units_accepted, model
+         int, Model: requested_units_accepted, model
      )pbdoc",
      py::arg("numbering"),
      py::arg("requested_length_unit"),

--- a/kimpy/KIM_Model_bind.cpp
+++ b/kimpy/KIM_Model_bind.cpp
@@ -1,345 +1,381 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
-#include <cstddef>
 #include <memory>
 #include <string>
 
 #include "KIM_SimulatorHeaders.hpp"
 #include "sim_buffer.h"
+#include "py_kim_wrapper.h"
 
 namespace py = pybind11;
 using namespace KIM;
 
-struct PyModelDestroy {
-  void operator()(Model *model) const {
-    Model::Destroy(&model);
-  }
-};
 
 PYBIND11_MODULE(model, module)
 {
   module.doc() = "Python binding to KIM_Model.hpp";
 
-  // C++ class constructor and destructor are private, which can not be wrapped
-  // directly.
-  // So we need to call the C++ class factory function in py::init, and use
-  // `py::nodelete` to avoid calling the destructor when python instance is
-  // destroyed. It is crucial that the instance is deallocated by calling the
-  // destroy function from the C++ side to avoid memory leaks. For more info,
-  // see http://pybind11.readthedocs.io/en/stable/advanced/classes.html
+  py::class_<PyModel, std::shared_ptr<PyModel>> cl(module, "PyModel");
 
-  py::class_<Model, std::unique_ptr<Model, PyModelDestroy>> cl(module, "Model");
+  cl.def(py::init([](Numbering const &numbering,
+                     LengthUnit const &requested_length_unit,
+                     EnergyUnit const &requested_energy_unit,
+                     ChargeUnit const &requested_charge_unit,
+                     TemperatureUnit const &requested_temperature_unit,
+                     TimeUnit const &requested_time_unit,
+                     std::string const &model_name,
+                     py::array_t<int> requested_units_accepted) {
+      int *kim_requested_units_accepted =
+        requested_units_accepted.mutable_data(0);
 
-  // python constructor needs to return a pointer to the C++ instance
-  cl.def(py::init([](Numbering const numbering,
-                     LengthUnit const requestedLengthUnit,
-                     EnergyUnit const requestedEnergyUnit,
-                     ChargeUnit const requestedChargeUnit,
-                     TemperatureUnit const requestedTemperatureUnit,
-                     TimeUnit const requestedTimeUnit,
-                     std::string const & modelName,
-                     py::array_t<int> requestedUnitsAccepted,
-                     py::array_t<int> error) {
-      Model * mo;
-      int * e = error.mutable_data(0);
-      int * r = requestedUnitsAccepted.mutable_data(0);
-      e[0] = Model::Create(numbering,
-                           requestedLengthUnit,
-                           requestedEnergyUnit,
-                           requestedChargeUnit,
-                           requestedTemperatureUnit,
-                           requestedTimeUnit,
-                           modelName,
-                           r,
-                           &mo);
-      return mo;
+      std::shared_ptr<PyModel> model(new PyModel());
+
+      int error = Model::Create(numbering,
+                                requested_length_unit,
+                                requested_energy_unit,
+                                requested_charge_unit,
+                                requested_temperature_unit,
+                                requested_time_unit,
+                                model_name,
+                                kim_requested_units_accepted,
+                                &model->_model);
+      if (error == 1) {
+        throw std::runtime_error(
+          "Unable to create a new KIM-API model object!");
+      }
+
+      return model;
     }))
+    .def("is_routine_present",
+         [](PyModel &self, ModelRoutineName const &model_routine_name) {
+      int present;
+      int required;
 
-      .def(
-          "is_routine_present",
-          [](Model & self, ModelRoutineName const modelRoutineName) {
-            int present;
-            int required;
-            int error
-                = self.IsRoutinePresent(modelRoutineName, &present, &required);
+      int error =
+        self._model->IsRoutinePresent(model_routine_name, &present, &required);
+      if (error == 1) {
+        throw std::runtime_error("model_routine_name = " +
+          model_routine_name.ToString() + "is unknown!");
+      }
 
-            py::tuple re(3);
-            re[0] = present;
-            re[1] = required;
-            re[2] = error;
-            return re;
-          },
-          py::arg("ModelRoutineName"),
-          "Return(present, required, error)")
+      py::tuple re(2);
+      re[0] = present;
+      re[1] = required;
+      return re;
+    }, "Determine presence and required status of the given "
+       "model_routine_name.",
+       py::arg("model_routine_name"),
+       "Return(present, required)")
+    .def("get_influence_distance", [](PyModel &self) {
+      double influence_distance;
 
-      .def(
-          "get_influence_distance",
-          [](Model & self) {
-            double influenceDistance;
-            self.GetInfluenceDistance(&influenceDistance);
+      self._model->GetInfluenceDistance(&influence_distance);
 
-            return influenceDistance;
-          },
-          "Return influenceDistance")
+      return influence_distance;
+    }, "Get the model's influence distance.",
+       "Return influence_distance")
+    .def("get_neighbor_list_cutoffs_and_hints", [](PyModel &self) {
+      int number_of_cutoffs;
+      double const *cutoff_ptr;
+      int const *kim_model_not_request_neighbors_of_noncontributing_particles;
 
-      .def(
-          "get_neighbor_list_cutoffs_and_hints",
-          [](Model & self) {
-            int numberOfCutoffs;
-            double const * cutoff_ptr;
-            int const * paddingNoNeighborHints_ptr;
-            self.GetNeighborListPointers(
-                &numberOfCutoffs, &cutoff_ptr, &paddingNoNeighborHints_ptr);
+      self._model->GetNeighborListPointers(
+        &number_of_cutoffs, &cutoff_ptr,
+        &kim_model_not_request_neighbors_of_noncontributing_particles);
 
-            py::array_t<double, py::array::c_style> cutoffs(numberOfCutoffs);
-            py::array_t<int, py::array::c_style>
-              paddingNoNeighborHints(numberOfCutoffs);
+      py::array_t<double, py::array::c_style> cutoffs(number_of_cutoffs);
+      py::array_t<int, py::array::c_style>
+        model_not_request_neighbors_of_noncontributing_particles(
+          number_of_cutoffs);
 
-            auto cut = cutoffs.mutable_data(0);
-            auto pnh = paddingNoNeighborHints.mutable_data(0);
-            for (int i = 0; i < numberOfCutoffs; i++)
-            {
-              cut[i] = cutoff_ptr[i];
-              pnh[i] = paddingNoNeighborHints_ptr[i];
-            }
+      auto cut = cutoffs.mutable_data(0);
+      auto pnh =
+        model_not_request_neighbors_of_noncontributing_particles.mutable_data(
+          0);
 
-            py::tuple re(2);
-            re[0] = cutoffs;
-            re[1] = paddingNoNeighborHints;
-            return re;
-          },
-          "Return(cutoffs, "
-          "model_not_request_neighbors_of_noncontributing_particles)")
+      for (int i = 0; i < number_of_cutoffs; i++)
+      {
+        cut[i] = cutoff_ptr[i];
+        pnh[i] =
+          kim_model_not_request_neighbors_of_noncontributing_particles[i];
+      }
 
-      .def(
-          "get_units",
-          [](Model & self) {
-            LengthUnit lengthUnit;
-            EnergyUnit energyUnit;
-            ChargeUnit chargeUnit;
-            TemperatureUnit temperatureUnit;
-            TimeUnit timeUnit;
-            self.GetUnits(&lengthUnit,
-                          &energyUnit,
-                          &chargeUnit,
-                          &temperatureUnit,
-                          &timeUnit);
+      py::tuple re(2);
+      re[0] = cutoffs;
+      re[1] = model_not_request_neighbors_of_noncontributing_particles;
+      return re;
+    }, "Get the model's neighbor list information.",
+       "Return(cutoffs, "
+       "model_not_request_neighbors_of_noncontributing_particles)")
+    .def("get_units", [](PyModel &self) {
+      LengthUnit length_unit;
+      EnergyUnit energy_unit;
+      ChargeUnit charge_unit;
+      TemperatureUnit temperature_unit;
+      TimeUnit time_unit;
 
-            py::tuple re(5);
-            re[0] = lengthUnit;
-            re[1] = energyUnit;
-            re[2] = chargeUnit;
-            re[3] = temperatureUnit;
-            re[4] = timeUnit;
-            return re;
-          },
-          "Return(LengthUnit, EnergyUnit, ChargeUnit, TemperatureUnit, "
-          "TimeUnit)")
+      self._model->GetUnits(&length_unit,
+                            &energy_unit,
+                            &charge_unit,
+                            &temperature_unit,
+                            &time_unit);
 
-      .def(
-          "compute_arguments_create",
-          [](Model & self) {
-            ComputeArguments * computeArguments;
-            int error = self.ComputeArgumentsCreate(&computeArguments);
-            py::tuple re(2);
-            re[0] = computeArguments;
-            re[1] = error;
-            return re;
-          },
-          "Return(ComputeArguments, error)")
+      py::tuple re(5);
+      re[0] = length_unit;
+      re[1] = energy_unit;
+      re[2] = charge_unit;
+      re[3] = temperature_unit;
+      re[4] = time_unit;
+      return re;
+    }, "Get the model's base unit values.",
+       "Return(length_unit, energy_unit, charge_unit, "
+       "temperature_unit, time_unit)")
+    .def("compute_arguments_create", [](std::shared_ptr<PyModel> self) {
+      std::shared_ptr<PyComputeArguments>
+        py_compute_arguments(new PyComputeArguments(self));
 
-      .def(
-          "compute_arguments_destroy",
-          [](Model & self, ComputeArguments * computeArguments) {
-            SimBuffer * sim_buffer;
-            computeArguments->GetSimulatorBufferPointer((void **) &sim_buffer);
-            if (sim_buffer)
-            {
-              for (std::size_t i = 0; i < sim_buffer->callbacks.size(); i++)
-              {
-                if (sim_buffer->callbacks[i]) delete sim_buffer->callbacks[i];
-              }
-              delete sim_buffer;
-              sim_buffer = nullptr;
-            }
+      int error = self->_model->ComputeArgumentsCreate(
+        &py_compute_arguments->_compute_arguments);
+      if (error == 1) {
+        throw std::runtime_error(
+          "Unable to create a new compute_arguments "
+          "object for the model object!");
+      }
 
-            int error = self.ComputeArgumentsDestroy(&computeArguments);
-            return error;
-          },
-          py::arg("ComputeArguments"),
-          "Return error")
+      return py_compute_arguments;
+    }, "Create a new compute_arguments object for the model object.",
+       "Return compute_arguments")
+    .def("compute",
+         [](PyModel &self,
+            std::shared_ptr<PyComputeArguments> compute_arguments,
+            bool release_GIL) {
+      ComputeArguments const *const kim_compute_arguments =
+        compute_arguments->_compute_arguments;
 
-      .def(
-          "compute",
-          [](Model & self,
-             ComputeArguments const * const computeArguments,
-             bool release_GIL) {
-            if (release_GIL)
-            {
-              py::gil_scoped_release release;
-              int error = self.Compute(computeArguments);
-              return error;
-            }
-            else
-            {
-              int error = self.Compute(computeArguments);
-              return error;
-            }
-          },
-          py::arg("ComputeArguments"),
-          py::arg("release_GIL") = false,
-          "Return error")
+      int error;
+      if (release_GIL)
+      {
+        py::gil_scoped_release release;
+        error = self._model->Compute(kim_compute_arguments);
+      }
+      else
+      {
+        error = self._model->Compute(kim_compute_arguments);
+      }
+      if (error == 1) {
+        throw std::runtime_error(
+          "the model does not provide an Extension routine!  or\n"
+          "the model's Extension routine returns error!");
+      }
+    }, "Call the model's Compute routine.",
+       py::arg("compute_arguments"),
+       py::arg("release_GIL") = false)
+    .def("clear_then_refresh", [](PyModel &self) {
+      self._model->ClearThenRefresh();
+    }, "Clear influence distance and neighbor list pointers and refresh "
+       "model object after parameter changes.")
+    .def("write_parameterized_model",
+         [](PyModel &self,
+            std::string const &path,
+            std::string const &model_name) {
+      int error = self._model->WriteParameterizedModel(path, model_name);
+      if (error == 1) {
+        throw std::runtime_error(
+          "the model object is not a parameterized model!  or\n"
+          "the model_name is not a valid C identifier!  or\n"
+          "the model's WriteParameterizedModel routine returns error!");
+      }
+    }, "Call the model's WriteParameterizedModel routine.",
+       py::arg("path"),
+       py::arg("model_name"))
+    .def("get_species_support_and_code",
+         [](PyModel &self, SpeciesName const &species_name) {
+      int species_is_supported;
+      int code = -1;
 
-      .def("clear_then_refresh", &Model::ClearThenRefresh)
+      int error = self._model->GetSpeciesSupportAndCode(
+        species_name, &species_is_supported, &code);
+      if (error == 1) {
+        throw std::runtime_error("species_name = " +
+          species_name.ToString() + " is unknown!");
+      }
 
-      .def(
-          "write_parameterized_model",
-          [](Model & self,
-             std::string const & path,
-             std::string const & modelName) {
-            int error = self.WriteParameterizedModel(path, modelName);
+      py::tuple re(2);
+      re[0] = species_is_supported;
+      re[1] = code;
+      return re;
+    }, "Get the model's support and code for the requested species_name.",
+       py::arg("species_name"),
+       "Return(species_is_supported, code)")
+    .def("get_number_of_parameters", [](PyModel &self) {
+      int number_pf_parameters;
 
-            return error;
-          },
-          py::arg("path"),
-          py::arg("modelName"),
-          "Return error")
+      self._model->GetNumberOfParameters(&number_pf_parameters);
 
-      .def(
-          "get_species_support_and_code",
-          [](Model & self, SpeciesName const speciesName) {
-            int speciesIsSupported;
-            int code = -1;
-            int error = self.GetSpeciesSupportAndCode(
-                speciesName, &speciesIsSupported, &code);
+      return number_pf_parameters;
+    }, "Get the number of parameter arrays provided by the model.",
+       "Return number_pf_parameters")
+    .def("get_parameter_metadata",
+         [](PyModel &self, int const parameter_index) {
+      DataType data_type;
+      int extent;
+      std::string const *name;
+      std::string const *description;
 
-            py::tuple re(3);
-            re[0] = speciesIsSupported;
-            re[1] = code;
-            re[2] = error;
-            return re;
-          },
-          py::arg("SpeciesName"),
-          "Return(speciesIsSupported, code, error)")
+      int error = self._model->GetParameterMetadata(
+        parameter_index, &data_type, &extent, &name, &description);
+      if (error == 1) {
+        throw std::runtime_error("parameter_index is invalid!");
+      }
 
-      .def(
-          "get_number_of_parameters",
-          [](Model & self) {
-            int numberOfParameters;
-            self.GetNumberOfParameters(&numberOfParameters);
-            return numberOfParameters;
-          },
-          "Return numberOfParameters")
+      py::tuple re(4);
+      re[0] = data_type;
+      re[1] = extent;
+      re[2] = *name;
+      re[3] = *description;
+      return re;
+    }, "Get the metadata associated with one of the "
+       "models's parameter arrays.",
+       py::arg("parameterIndex"),
+       "Return(data_type, extent, name, description)")
+    .def("get_parameter_int",
+         [](PyModel &self, int const parameter_index, int const array_index) {
+      int parameter_value;
 
-      .def(
-          "get_parameter_metadata",
-          [](Model & self, int const index) {
-            DataType dataType;
-            int extent;
-            std::string const * name;
-            std::string const * description;
+      int error =
+        self._model->GetParameter(
+          parameter_index, array_index, &parameter_value);
+      if (error == 1) {
+        throw std::runtime_error(
+          "parameter_index = " + std::to_string(parameter_index) +
+          " is invalid!  or\nthe specified parameter "
+          "and parameter_value are of different data types!  or\n"
+          "array_index = " + std::to_string(array_index) + "is invalid!");
+      }
 
-            int error = self.GetParameterMetadata(
-                index, &dataType, &extent, &name, &description);
-            py::tuple re(5);
-            re[0] = dataType;
-            re[1] = extent;
-            re[2] = *name;
-            re[3] = *description;
-            re[4] = error;
-            return re;
-          },
-          py::arg("index"),
-          "Return(DataType, extent, description, error)")
+      return parameter_value;
+    }, "Get an int parameter value from the Model.",
+       py::arg("parameter_index"),
+       py::arg("array_index"),
+       "Return parameter_value")
+    .def("get_parameter_double",
+         [](PyModel &self, int const parameter_index, int const array_index) {
+      double parameter_value;
 
-      .def(
-          "get_parameter_int",
-          [](Model & self, int const parameterIndex, int const arrayIndex) {
-            int parameterValue;
-            int error = self.GetParameter(
-                parameterIndex, arrayIndex, &parameterValue);
+      int error =
+        self._model->GetParameter(
+          parameter_index, array_index, &parameter_value);
+      if (error == 1) {
+        throw std::runtime_error(
+          "parameter_index = " + std::to_string(parameter_index) +
+          " is invalid!  or\nthe specified parameter "
+          "and parameter_value are of different data types!  or\n"
+          "array_index = " + std::to_string(array_index) + " is invalid!");
+      }
 
-            py::tuple re(2);
-            re[0] = parameterValue;
-            re[1] = error;
-            return re;
-          },
-          py::arg("parameterIndex"),
-          py::arg("arrayIndex"),
-          "Return(parameterValue, error)")
-
-      .def(
-          "get_parameter_double",
-          [](Model & self, int const parameterIndex, int const arrayIndex) {
-            double parameterValue;
-            int error = self.GetParameter(
-                parameterIndex, arrayIndex, &parameterValue);
-
-            py::tuple re(2);
-            re[0] = parameterValue;
-            re[1] = error;
-            return re;
-          },
-          py::arg("parameterIndex"),
-          py::arg("arrayIndex"),
-          "Return(parameterValue, error)")
-
-      // overloaded function
-      .def("set_parameter",
-           (int (Model::*)(int const, int const, int const))
-               & Model::SetParameter)
-
-      .def("set_parameter",
-           (int (Model::*)(int const, int const, double const))
-               & Model::SetParameter)
-
-      .def("__repr__", &Model::ToString)
-
-      .def("set_log_id", &Model::SetLogID)
-
-      .def("push_log_verbosity", &Model::PushLogVerbosity)
-
-      .def("pop_log_verbosity", &Model::PopLogVerbosity);
-
+      return parameter_value;
+    }, "Get a double parameter value from the Model.",
+       py::arg("parameter_index"),
+       py::arg("array_index"),
+       "Return parameter_value")
+    // overloaded function
+    .def("set_parameter",
+          [](PyModel &self,
+             int const parameter_index,
+             int const array_index,
+             int const parameter_value) {
+      int error =
+        self._model->SetParameter(
+          parameter_index, array_index, parameter_value);
+      if (error == 1) {
+        throw std::runtime_error(
+          "parameter_index = " + std::to_string(parameter_index) +
+          " is invalid!  or\nthe specified parameter "
+          "and parameter_value are of different data types!  or\n"
+          "array_index = " + std::to_string(array_index) + " is invalid!");
+      }
+    }, "Set an int parameter value for the Model.",
+       py::arg("parameter_index"),
+       py::arg("array_index"),
+       py::arg("parameter_value"))
+    .def("set_parameter",
+          [](PyModel &self,
+             int const parameter_index,
+             int const array_index,
+             double const parameter_value) {
+      int error =
+        self._model->SetParameter(
+          parameter_index, array_index, parameter_value);
+      if (error == 1) {
+        throw std::runtime_error(
+          "parameter_index = " + std::to_string(parameter_index) +
+          " is invalid!  or\nthe specified parameter "
+          "and parameter_value are of different data types!  or\n"
+          "array_index = " + std::to_string(array_index) + " is invalid!");
+      }
+    }, "Set an int parameter value for the Model.",
+       py::arg("parameter_index"),
+       py::arg("array_index"),
+       py::arg("parameter_value"))
+    .def("__repr__", [](PyModel &self) {
+      return self._model->ToString();
+    },"A string representing the internal state of the model object.")
+    .def("set_log_id", [](PyModel &self, std::string const &log_id) {
+      self._model->SetLogID(log_id);
+    }, "Set the identity of the Log object associated "
+       "with the model object.",
+       py::arg("log_id"))
+    .def("push_log_verbosity",
+         [](PyModel &self, LogVerbosity const &log_verbosity) {
+      self._model->PushLogVerbosity(log_verbosity);
+    }, "Push a new LogVerbosity onto the Model object's Log object "
+       "verbosity stack.",
+       py::arg("log_verbosity"))
+    .def("pop_log_verbosity", [](PyModel &self) {
+      self._model->PopLogVerbosity();
+    }, "Pop a LogVerbosity from the Model object's Log object "
+       "verbosity stack.");
 
   // module functions
 
-  module.def(
-      "create",
-      [](Numbering const numbering,
-         LengthUnit const requestedLengthUnit,
-         EnergyUnit const requestedEnergyUnit,
-         ChargeUnit const requestedChargeUnit,
-         TemperatureUnit const requestedTemperatureUnit,
-         TimeUnit const requestedTimeUnit,
-         std::string const & modelName) {
-        Model * mo;
-        int requestedUnitsAccepted;
-        int error = Model::Create(numbering,
-                                  requestedLengthUnit,
-                                  requestedEnergyUnit,
-                                  requestedChargeUnit,
-                                  requestedTemperatureUnit,
-                                  requestedTimeUnit,
-                                  modelName,
-                                  &requestedUnitsAccepted,
-                                  &mo);
+  module.def("create",
+             [](Numbering const &numbering,
+                LengthUnit const &requested_length_unit,
+                EnergyUnit const &requested_energy_unit,
+                ChargeUnit const &requested_charge_unit,
+                TemperatureUnit const &requested_temperature_unit,
+                TimeUnit const &requested_time_unit,
+                std::string const &model_name) {
+    int requested_units_accepted;
 
-        py::tuple re(3);
-        re[0] = requestedUnitsAccepted;
-        re[1] = mo;
-        re[2] = error;
-        return re;
-      },
-      py::arg("Numbering"),
-      py::arg("LengthUnit"),
-      py::arg("EnergyUnit"),
-      py::arg("ChargeUnit"),
-      py::arg("TemperatureUnit"),
-      py::arg("TimeUnit"),
-      py::arg("modelName"),
-      "Return(requestedUnitsAccepted, Model, error)");
+    std::shared_ptr<PyModel> model(new PyModel());
 
-  module.def("destroy", [](Model * self) { Model::Destroy(&self); });
+    int error = Model::Create(numbering,
+                              requested_length_unit,
+                              requested_energy_unit,
+                              requested_charge_unit,
+                              requested_temperature_unit,
+                              requested_time_unit,
+                              model_name,
+                              &requested_units_accepted,
+                              &model->_model);
+    if (error == 1) {
+      throw std::runtime_error(
+        "Unable to create a new KIM-API model object!");
+    }
+
+    py::tuple re(2);
+    re[0] = requested_units_accepted;
+    re[1] = model;
+    return re;
+  }, "Create a new KIM-API model object.",
+     py::arg("numbering"),
+     py::arg("requested_length_unit"),
+     py::arg("requested_energy_unit"),
+     py::arg("requested_charge_unit"),
+     py::arg("requested_temperature_unit"),
+     py::arg("requested_time_unit"),
+     py::arg("model_name"),
+     "Return(requested_units_accepted, model)");
 }

--- a/kimpy/KIM_SemVer_bind.cpp
+++ b/kimpy/KIM_SemVer_bind.cpp
@@ -18,8 +18,12 @@ PYBIND11_MODULE(sem_ver, module)
     std::string const &version = SEM_VER::GetSemVer();
 
     return version;
-  }, "Get the KIM-API complete Semantic Version string.",
-     "Return version");
+  }, R"pbdoc(
+     Get the KIM-API complete Semantic Version string.
+
+     Returns:
+         str: version
+     )pbdoc");
 
   module.def("is_less_than",
       [](std::string const &version_a, std::string const &version_b) {
@@ -32,10 +36,14 @@ PYBIND11_MODULE(sem_ver, module)
     }
 
     return is_less_than;
-  }, "Compare two Semantic Version strings.",
+  }, R"pbdoc(
+     Compare two Semantic Version strings.
+
+     Returns:
+         int: is_less_than
+     )pbdoc",
      py::arg("version_a"),
-     py::arg("version_b"),
-     "Return is_less_than");
+     py::arg("version_b"));
 
   module.def("parse_sem_ver", [](std::string const &version) {
     int major;
@@ -63,7 +71,12 @@ PYBIND11_MODULE(sem_ver, module)
     re[3] = prerelease;
     re[4] = build_metadata;
     return re;
-  }, "Parse Semantic Version string into its six components.",
-     py::arg("version"),
-     "Return(major, minor, patch, prerelease, build_metadata)");
+  }, R"pbdoc(
+     Parse Semantic Version string into its six components.
+
+     Returns:
+         int, int, int, str, str: major, minor, patch, prerelease,
+             build_metadata
+     )pbdoc",
+     py::arg("version"));
 }

--- a/kimpy/KIM_SemVer_bind.cpp
+++ b/kimpy/KIM_SemVer_bind.cpp
@@ -15,45 +15,55 @@ PYBIND11_MODULE(sem_ver, module)
   module.doc() = "Python binding to KIM_SymVer.hpp";
 
   module.def("get_sem_ver", []() {
-    std::string const & version = SEM_VER::GetSemVer();
+    std::string const &version = SEM_VER::GetSemVer();
+
     return version;
-  });
+  }, "Get the KIM-API complete Semantic Version string.",
+     "Return version");
 
-  module.def(
-      "is_less_than",
-      [](std::string const & versionA, std::string const & versionB) {
-        int isLessThan;
-        int error = SEM_VER::IsLessThan(versionA, versionB, &isLessThan);
+  module.def("is_less_than",
+      [](std::string const &version_a, std::string const &version_b) {
+    int is_less_than;
 
-        py::tuple re(2);
-        re[0] = isLessThan;
-        re[1] = error;
-        return re;
-      },
-      py::arg("versionA"),
-      py::arg("versionB"),
-      "Return(isLessThan, error)");
+    int error = SEM_VER::IsLessThan(version_a, version_b, &is_less_than);
+    if (error == 1) {
+      throw std::runtime_error(
+        "ParseSemVer (Parse Semantic Version) returns error for lhs or rhs!");
+    }
 
-  module.def(
-      "parse_sem_ver",
-      [](std::string const & version) {
-        int major;
-        int minor;
-        int patch;
-        std::string prerelease;
-        std::string buildMetadata;
-        int error = SEM_VER::ParseSemVer(
-            version, &major, &minor, &patch, &prerelease, &buildMetadata);
+    return is_less_than;
+  }, "Compare two Semantic Version strings.",
+     py::arg("version_a"),
+     py::arg("version_b"),
+     "Return is_less_than");
 
-        py::tuple re(6);
-        re[0] = major;
-        re[1] = minor;
-        re[2] = patch;
-        re[3] = prerelease;
-        re[4] = buildMetadata;
-        re[5] = error;
-        return re;
-      },
-      py::arg("version"),
-      "Return(major, minor, patch, prerelease, buildMetadata, error)");
+  module.def("parse_sem_ver", [](std::string const &version) {
+    int major;
+    int minor;
+    int patch;
+    std::string prerelease;
+    std::string build_metadata;
+
+    int error = SEM_VER::ParseSemVer(
+      version, &major, &minor, &patch, &prerelease, &build_metadata);
+    if (error == 1) {
+      throw std::runtime_error(
+        "minor and/or patch are missing!  or\n"
+        "major number has a leading zero or is not a valid integer!  or\n"
+        "minor number has a leading zero or is not a valid integer!  or\n"
+        "patch number has a leading zero or is not a valid integer!  or\n"
+        "the prerelease string is invalid!  or\n"
+        "the build metadata string is invalid!");
+    }
+
+    py::tuple re(5);
+    re[0] = major;
+    re[1] = minor;
+    re[2] = patch;
+    re[3] = prerelease;
+    re[4] = build_metadata;
+    return re;
+  }, "Parse Semantic Version string into its six components.",
+     py::arg("version"),
+     "Return(major, minor, patch, prerelease, build_metadata)");
 }

--- a/kimpy/KIM_SemVer_bind.cpp
+++ b/kimpy/KIM_SemVer_bind.cpp
@@ -15,7 +15,7 @@ PYBIND11_MODULE(sem_ver, module)
   module.doc() = "Python binding to KIM_SymVer.hpp";
 
   module.def("get_sem_ver", []() {
-    std::string const &version = SEM_VER::GetSemVer();
+    std::string const & version = SEM_VER::GetSemVer();
 
     return version;
   }, R"pbdoc(
@@ -30,9 +30,10 @@ PYBIND11_MODULE(sem_ver, module)
     int is_less_than;
 
     int error = SEM_VER::IsLessThan(version_a, version_b, &is_less_than);
-    if (error == 1) {
+    if (error == 1)
+    {
       throw std::runtime_error(
-        "ParseSemVer (Parse Semantic Version) returns error for lhs or rhs!");
+          "ParseSemVer (Parse Semantic Version) returns error for lhs or rhs!");
     }
 
     return is_less_than;
@@ -53,15 +54,16 @@ PYBIND11_MODULE(sem_ver, module)
     std::string build_metadata;
 
     int error = SEM_VER::ParseSemVer(
-      version, &major, &minor, &patch, &prerelease, &build_metadata);
-    if (error == 1) {
+        version, &major, &minor, &patch, &prerelease, &build_metadata);
+    if (error == 1)
+    {
       throw std::runtime_error(
-        "minor and/or patch are missing!  or\n"
-        "major number has a leading zero or is not a valid integer!  or\n"
-        "minor number has a leading zero or is not a valid integer!  or\n"
-        "patch number has a leading zero or is not a valid integer!  or\n"
-        "the prerelease string is invalid!  or\n"
-        "the build metadata string is invalid!");
+          "minor and/or patch are missing!  or\n"
+          "major number has a leading zero or is not a valid integer!  or\n"
+          "minor number has a leading zero or is not a valid integer!  or\n"
+          "patch number has a leading zero or is not a valid integer!  or\n"
+          "the prerelease string is invalid!  or\n"
+          "the build metadata string is invalid!");
     }
 
     py::tuple re(5);

--- a/kimpy/KIM_SimulatorModel_bind.cpp
+++ b/kimpy/KIM_SimulatorModel_bind.cpp
@@ -52,16 +52,24 @@ PYBIND11_MODULE(simulator_model, module)
       re[0] = *simulator_name;
       re[1] = *simulator_version;
       return re;
-    }, "Get the simulator_model's simulator name and version.",
-       "Return(simulator_name, simulator_version)")
+    }, R"pbdoc(
+       Get the simulator_model's simulator name and version.
+
+       Returns:
+           str, str: simulator_name, simulator_version
+       )pbdoc")
     .def("get_number_of_supported_species", [](SimulatorModel &self) {
       int number_of_supported_species;
 
       self.GetNumberOfSupportedSpecies(&number_of_supported_species);
 
       return number_of_supported_species;
-    }, "Get the number of species supported by the simulator_model.",
-       "Return number_of_supported_species")
+    }, R"pbdoc(
+       Get the number of species supported by the simulator_model.
+
+       Returns:
+           int: number_of_supported_species
+       )pbdoc")
     .def("get_supported_species", [](SimulatorModel &self, int const index) {
       std::string const *species_name;
 
@@ -71,9 +79,13 @@ PYBIND11_MODULE(simulator_model, module)
       }
 
       return *species_name;
-    }, "Get a species name supported by the simulator_model.",
-       py::arg("index"),
-       "Return species_name")
+    }, R"pbdoc(
+       Get a species name supported by the simulator_model.
+
+       Returns:
+           str: species_name
+       )pbdoc",
+       py::arg("index"))
     .def("open_and_initialize_template_map",
          &SimulatorModel::OpenAndInitializeTemplateMap,
          "Open and initialize the template map for simulator field line "
@@ -101,8 +113,12 @@ PYBIND11_MODULE(simulator_model, module)
       self.GetNumberOfSimulatorFields(&number_of_simulator_fields);
 
       return number_of_simulator_fields;
-    }, "Get the number of simulator fields provided by the simulator_model.",
-       "Return number_of_simulator_fields")
+    }, R"pbdoc(
+       Get the number of simulator fields provided by the simulator_model.
+
+       Returns:
+           int: number_of_simulator_fields
+       )pbdoc")
     .def("get_simulator_field_metadata",
          [](SimulatorModel &self, int const field_index) {
       int extent;
@@ -118,9 +134,13 @@ PYBIND11_MODULE(simulator_model, module)
       re[0] = extent;
       re[1] = *field_name;
       return re;
-    }, "Get the metadata for the simulator field of interest.",
-       py::arg("field_index"),
-       "Return(extent, field_name)")
+    }, R"pbdoc(
+       Get the metadata for the simulator field of interest.
+
+       Returns:
+           int, str: extent, field_name
+       )pbdoc",
+       py::arg("field_index"))
     .def("get_simulator_field_line",
          [](SimulatorModel &self,
             int const field_index,
@@ -137,38 +157,54 @@ PYBIND11_MODULE(simulator_model, module)
       }
 
       return *line_value;
-    }, "Get a line for the simulator field of interest with all template "
-       "substitutions performed (Requires the template map is closed).",
+    }, R"pbdoc(
+       Get a line for the simulator field of interest with all template
+       substitutions performed (Requires the template map is closed).
+
+       Returns:
+           str: line_value
+       )pbdoc",
        py::arg("field_index"),
-       py::arg("line_index"),
-       "Return line_value")
+       py::arg("line_index"))
     .def("get_parameter_file_directory_name", [](SimulatorModel &self) {
       std::string const *directory_name;
 
       self.GetParameterFileDirectoryName(&directory_name);
 
       return *directory_name;
-    }, "Get absolute path name of the temporary directory where parameter "
-       "files provided by the simulator model are written.",
-       "Return directory_name")
+    }, R"pbdoc(
+       Get absolute path name of the temporary directory where parameter
+       files provided by the simulator model are written.
+
+       Returns:
+           str: directory_name
+       )pbdoc")
     .def("get_specification_file_name", [](SimulatorModel &self) {
       std::string const *specification_file_name;
 
       self.GetSpecificationFileName(&specification_file_name);
 
       return *specification_file_name;
-    }, "Get the simulator_model's specification file basename (file name "
-       "without path).  The file is located in the simulator_model's "
-       "parameter file directory.",
-       "Return specification_file_name")
+    }, R"pbdoc(
+       Get the simulator_model's specification file basename (file name without
+       path).  The file is located in the simulator_model's parameter file
+       directory.
+
+       Returns:
+           str: specification_file_name
+       )pbdoc")
     .def("get_number_of_parameter_files", [](SimulatorModel &self) {
       int number_of_parameter_files;
 
       self.GetNumberOfParameterFiles(&number_of_parameter_files);
 
       return number_of_parameter_files;
-    }, "Get the number of parameter files provided by the simulator_model.",
-       "Return number_of_parameter_files")
+    }, R"pbdoc(
+       Get the number of parameter files provided by the simulator_model.
+
+       Returns:
+           int: number_of_parameter_files
+       )pbdoc")
     .def("get_parameter_file_name",
          [](SimulatorModel &self, int const index) {
       std::string const *parameter_file_name;
@@ -179,11 +215,15 @@ PYBIND11_MODULE(simulator_model, module)
       }
 
       return *parameter_file_name;
-    }, "Get the basename (file name without path) of a particular "
-       "parameter file.  The file is located in the simulator_model's "
-       "parameter file directory.",
-       py::arg("index"),
-       "Return parameter_file_name")
+    }, R"pbdoc(
+       Get the basename (file name without path) of a particular parameter
+       file.  The file is located in the simulator_model's parameter file
+       directory.
+
+       Returns:
+           str: parameter_file_name
+       )pbdoc",
+       py::arg("index"))
     .def("get_parameter_file_base_name",
          [](SimulatorModel &self, int const index) {
       std::string const *param_file_base_name;
@@ -194,11 +234,15 @@ PYBIND11_MODULE(simulator_model, module)
       }
 
       return *param_file_base_name;
-    }, "Get the basename (file name without path) of a particular "
-       "parameter file.  The file is located in the simulator_model's "
-       "parameter file directory.",
-       py::arg("index"),
-       "Return param_file_base_name")
+    }, R"pbdoc(
+       Get the basename (file name without path) of a particular parameter
+       file.  The file is located in the simulator_model's parameter file
+       directory.
+
+       Returns:
+           str: param_file_base_name
+       )pbdoc",
+       py::arg("index"))
     .def("__repr__", &SimulatorModel::ToString)
     .def("set_log_id", &SimulatorModel::SetLogID,
          "Set the identity of the Log object associated with the "
@@ -225,6 +269,10 @@ PYBIND11_MODULE(simulator_model, module)
 
     return std::unique_ptr<SimulatorModel, PySimulatorModelDestroy>(
       std::move(simulator_model));
-  }, "Create a new KIM-API simulator_model object.",
-     "Return simulator_model");
+  }, R"pbdoc(
+     Create a new KIM-API simulator_model object.
+
+     Returns:
+         simulator_model
+     )pbdoc");
 }

--- a/kimpy/KIM_SimulatorModel_bind.cpp
+++ b/kimpy/KIM_SimulatorModel_bind.cpp
@@ -10,6 +10,11 @@
 namespace py = pybind11;
 using namespace KIM;
 
+struct PySimulatorModelDestroy {
+  void operator()(SimulatorModel *simulator_model) const {
+    SimulatorModel::Destroy(&simulator_model);
+  }
+};
 
 PYBIND11_MODULE(simulator_model, module)
 {
@@ -23,7 +28,8 @@ PYBIND11_MODULE(simulator_model, module)
   // destroy function from the C++ side to avoid memory leaks. For more info,
   // see http://pybind11.readthedocs.io/en/stable/advanced/classes.html
 
-  py::class_<SimulatorModel, std::unique_ptr<SimulatorModel, py::nodelete> > 
+  py::class_<SimulatorModel,
+    std::unique_ptr<SimulatorModel, PySimulatorModelDestroy>>
     cl(module, "SimulatorModel");
 
   // python constructor needs to return a pointer to the C++ instance

--- a/kimpy/KIM_SimulatorModel_bind.cpp
+++ b/kimpy/KIM_SimulatorModel_bind.cpp
@@ -11,13 +11,16 @@ namespace py = pybind11;
 using namespace KIM;
 
 
-namespace {
-struct PySimulatorModelDestroy {
-  void operator()(SimulatorModel *simulator_model) const {
+namespace
+{
+struct PySimulatorModelDestroy
+{
+  void operator()(SimulatorModel * simulator_model) const
+  {
     SimulatorModel::Destroy(&simulator_model);
   }
 };
-} // namespace
+}  // namespace
 
 
 PYBIND11_MODULE(simulator_model, module)
@@ -25,62 +28,59 @@ PYBIND11_MODULE(simulator_model, module)
   module.doc() = "Python binding to KIM_SimulatorModel.hpp";
 
   py::class_<SimulatorModel,
-    std::unique_ptr<SimulatorModel, PySimulatorModelDestroy>>
-    cl(module, "SimulatorModel");
+             std::unique_ptr<SimulatorModel, PySimulatorModelDestroy> >
+      cl(module, "SimulatorModel");
 
   // python constructor needs to return a pointer to the C++ instance
   cl.def(py::init([](std::string const &simulator_model_name) {
-      SimulatorModel *simulator_model;
+    SimulatorModel * simulator_model;
 
-      int error =
-        SimulatorModel::Create(simulator_model_name, &simulator_model);
-      if (error == 1) {
-        throw std::runtime_error(
-          "Unable to create a new KIM-API model object!");
-      }
+    int error = SimulatorModel::Create(simulator_model_name, &simulator_model);
+    if (error == 1)
+    {
+      throw std::runtime_error("Unable to create a new KIM-API Model object!");
+    }
 
-      return std::unique_ptr<SimulatorModel, PySimulatorModelDestroy>(
+    return std::unique_ptr<SimulatorModel, PySimulatorModelDestroy>(
         std::move(simulator_model));
     }))
     .def("get_simulator_name_and_version", [](SimulatorModel &self) {
-      std::string const *simulator_name;
-      std::string const *simulator_version;
+    std::string const * simulator_name;
+    std::string const * simulator_version;
 
-      self.GetSimulatorNameAndVersion(&simulator_name, &simulator_version);
+    self.GetSimulatorNameAndVersion(&simulator_name, &simulator_version);
 
-      py::tuple re(2);
-      re[0] = *simulator_name;
-      re[1] = *simulator_version;
-      return re;
+    py::tuple re(2);
+    re[0] = *simulator_name;
+    re[1] = *simulator_version;
+    return re;
     }, R"pbdoc(
-       Get the simulator_model's simulator name and version.
+       Get the SimulatorModel's simulator name and version.
 
        Returns:
            str, str: simulator_name, simulator_version
        )pbdoc")
     .def("get_number_of_supported_species", [](SimulatorModel &self) {
-      int number_of_supported_species;
+    int number_of_supported_species;
 
-      self.GetNumberOfSupportedSpecies(&number_of_supported_species);
+    self.GetNumberOfSupportedSpecies(&number_of_supported_species);
 
-      return number_of_supported_species;
+    return number_of_supported_species;
     }, R"pbdoc(
-       Get the number of species supported by the simulator_model.
+       Get the number of species supported by the SimulatorModel.
 
        Returns:
            int: number_of_supported_species
        )pbdoc")
     .def("get_supported_species", [](SimulatorModel &self, int const index) {
-      std::string const *species_name;
+    std::string const * species_name;
 
-      int error = self.GetSupportedSpecies(index, &species_name);
-      if (error == 1) {
-        throw std::runtime_error("index is invalid!");
-      }
+    int error = self.GetSupportedSpecies(index, &species_name);
+    if (error == 1) { throw std::runtime_error("index is invalid!"); }
 
-      return *species_name;
+    return *species_name;
     }, R"pbdoc(
-       Get a species name supported by the simulator_model.
+       Get a species name supported by the SimulatorModel.
 
        Returns:
            str: species_name
@@ -96,44 +96,43 @@ PYBIND11_MODULE(simulator_model, module)
          [](SimulatorModel &self,
             std::string const &key,
             std::string const &value) {
-      int error = self.AddTemplateMap(key, value);
-      if (error == 1) {
-        throw std::runtime_error(
+    int error = self.AddTemplateMap(key, value);
+    if (error == 1)
+    {
+      throw std::runtime_error(
           "the template map has been closed by a call to "
           "close_template_map!  or\nkey contains invalid characters!");
-      }
+    }
     }, "Add a new key-value entry to the template map.",
        py::arg("key"),
        py::arg("value"))
     .def("close_template_map", &SimulatorModel::CloseTemplateMap,
          "Close the template map and perform template substitutions.")
     .def("get_number_of_simulator_fields", [](SimulatorModel &self) {
-      int number_of_simulator_fields;
+    int number_of_simulator_fields;
 
-      self.GetNumberOfSimulatorFields(&number_of_simulator_fields);
+    self.GetNumberOfSimulatorFields(&number_of_simulator_fields);
 
-      return number_of_simulator_fields;
+    return number_of_simulator_fields;
     }, R"pbdoc(
-       Get the number of simulator fields provided by the simulator_model.
+       Get the number of simulator fields provided by the SimulatorModel.
 
        Returns:
            int: number_of_simulator_fields
        )pbdoc")
     .def("get_simulator_field_metadata",
          [](SimulatorModel &self, int const field_index) {
-      int extent;
-      std::string const *field_name;
+    int extent;
+    std::string const * field_name;
 
-      int error = self.GetSimulatorFieldMetadata(
-        field_index, &extent, &field_name);
-      if (error == 1) {
-        throw std::runtime_error("field_index is invalid!");
-      }
+    int error
+        = self.GetSimulatorFieldMetadata(field_index, &extent, &field_name);
+    if (error == 1) { throw std::runtime_error("field_index is invalid!"); }
 
-      py::tuple re(2);
-      re[0] = extent;
-      re[1] = *field_name;
-      return re;
+    py::tuple re(2);
+    re[0] = extent;
+    re[1] = *field_name;
+    return re;
     }, R"pbdoc(
        Get the metadata for the simulator field of interest.
 
@@ -145,18 +144,18 @@ PYBIND11_MODULE(simulator_model, module)
          [](SimulatorModel &self,
             int const field_index,
             int const line_index) {
-      std::string const *line_value;
+    std::string const * line_value;
 
-      int error =
-        self.GetSimulatorFieldLine(field_index, line_index, &line_value);
-      if (error == 1) {
-        throw std::runtime_error(
-          "the template map is open!  or\n"
-          "field_index is invalid!    or\n"
-          "line_index is invalid!");
-      }
+    int error
+        = self.GetSimulatorFieldLine(field_index, line_index, &line_value);
+    if (error == 1)
+    {
+      throw std::runtime_error("the template map is open!  or\n"
+                               "field_index is invalid!    or\n"
+                               "line_index is invalid!");
+    }
 
-      return *line_value;
+    return *line_value;
     }, R"pbdoc(
        Get a line for the simulator field of interest with all template
        substitutions performed (Requires the template map is closed).
@@ -167,57 +166,55 @@ PYBIND11_MODULE(simulator_model, module)
        py::arg("field_index"),
        py::arg("line_index"))
     .def("get_parameter_file_directory_name", [](SimulatorModel &self) {
-      std::string const *directory_name;
+    std::string const * directory_name;
 
-      self.GetParameterFileDirectoryName(&directory_name);
+    self.GetParameterFileDirectoryName(&directory_name);
 
-      return *directory_name;
+    return *directory_name;
     }, R"pbdoc(
        Get absolute path name of the temporary directory where parameter
-       files provided by the simulator model are written.
+       files provided by the SimulatorModel are written.
 
        Returns:
            str: directory_name
        )pbdoc")
     .def("get_specification_file_name", [](SimulatorModel &self) {
-      std::string const *specification_file_name;
+    std::string const * specification_file_name;
 
-      self.GetSpecificationFileName(&specification_file_name);
+    self.GetSpecificationFileName(&specification_file_name);
 
-      return *specification_file_name;
+    return *specification_file_name;
     }, R"pbdoc(
-       Get the simulator_model's specification file basename (file name without
-       path).  The file is located in the simulator_model's parameter file
+       Get the SimulatorModel's specification file basename (file name without
+       path).  The file is located in the SimulatorModel's parameter file
        directory.
 
        Returns:
            str: specification_file_name
        )pbdoc")
     .def("get_number_of_parameter_files", [](SimulatorModel &self) {
-      int number_of_parameter_files;
+    int number_of_parameter_files;
 
-      self.GetNumberOfParameterFiles(&number_of_parameter_files);
+    self.GetNumberOfParameterFiles(&number_of_parameter_files);
 
-      return number_of_parameter_files;
+    return number_of_parameter_files;
     }, R"pbdoc(
-       Get the number of parameter files provided by the simulator_model.
+       Get the number of parameter files provided by the SimulatorModel.
 
        Returns:
            int: number_of_parameter_files
        )pbdoc")
     .def("get_parameter_file_name",
          [](SimulatorModel &self, int const index) {
-      std::string const *parameter_file_name;
+    std::string const * parameter_file_name;
 
-      int error = self.GetParameterFileName(index, &parameter_file_name);
-      if (error == 1) {
-        throw std::runtime_error("index is invalid!");
-      }
+    int error = self.GetParameterFileName(index, &parameter_file_name);
+    if (error == 1) { throw std::runtime_error("index is invalid!"); }
 
-      return *parameter_file_name;
+    return *parameter_file_name;
     }, R"pbdoc(
        Get the basename (file name without path) of a particular parameter
-       file.  The file is located in the simulator_model's parameter file
+       file.  The file is located in the SimulatorModel's parameter file
        directory.
 
        Returns:
@@ -226,17 +223,15 @@ PYBIND11_MODULE(simulator_model, module)
        py::arg("index"))
     .def("get_parameter_file_base_name",
          [](SimulatorModel &self, int const index) {
-      std::string const *param_file_base_name;
+    std::string const * param_file_base_name;
 
-      int error = self.GetParameterFileBasename(index, &param_file_base_name);
-      if (error == 1) {
-        throw std::runtime_error("index is invalid!");
-      }
+    int error = self.GetParameterFileBasename(index, &param_file_base_name);
+    if (error == 1) { throw std::runtime_error("index is invalid!"); }
 
-      return *param_file_base_name;
+    return *param_file_base_name;
     }, R"pbdoc(
        Get the basename (file name without path) of a particular parameter
-       file.  The file is located in the simulator_model's parameter file
+       file.  The file is located in the SimulatorModel's parameter file
        directory.
 
        Returns:
@@ -246,33 +241,36 @@ PYBIND11_MODULE(simulator_model, module)
     .def("__repr__", &SimulatorModel::ToString)
     .def("set_log_id", &SimulatorModel::SetLogID,
          "Set the identity of the Log object associated with the "
-         "simulator_model object.",
+         "SimulatorModel object.",
          py::arg("log_id"))
     .def("push_log_verbosity", &SimulatorModel::PushLogVerbosity,
-         "Push a new log_verbosity onto the simulator_model object's Log "
+         "Push a new log_verbosity onto the SimulatorModel object's Log "
          "object verbosity stack.",
          py::arg("log_verbosity"))
     .def("pop_log_verbosity", &SimulatorModel::PopLogVerbosity,
-         "Pop a log_verbosity from the simulator_model object's Log object "
+         "Pop a log_verbosity from the SimulatorModel object's Log object "
          "verbosity stack.");
 
   // module functions
 
-  module.def("create", [](std::string const &simulator_model_name) {
-    SimulatorModel *simulator_model;
+  module.def(
+      "create",
+      [](std::string const & simulator_model_name) {
+    SimulatorModel * simulator_model;
 
     int error = SimulatorModel::Create(simulator_model_name, &simulator_model);
-    if (error == 1) {
-      throw std::runtime_error(
-        "Unable to create a new KIM-API Model object!");
+    if (error == 1)
+    {
+      throw std::runtime_error("Unable to create a new KIM-API Model object!");
     }
 
     return std::unique_ptr<SimulatorModel, PySimulatorModelDestroy>(
-      std::move(simulator_model));
-  }, R"pbdoc(
-     Create a new KIM-API simulator_model object.
+        std::move(simulator_model));
+      }, R"pbdoc(
+         Create a new KIM-API SimulatorModel object.
 
-     Returns:
-         SimulatorModel: simulator_model
-     )pbdoc");
+         Returns:
+             SimulatorModel: simulator_model
+         )pbdoc"
+      );
 }

--- a/kimpy/KIM_SimulatorModel_bind.cpp
+++ b/kimpy/KIM_SimulatorModel_bind.cpp
@@ -273,6 +273,6 @@ PYBIND11_MODULE(simulator_model, module)
      Create a new KIM-API simulator_model object.
 
      Returns:
-         simulator_model
+         SimulatorModel: simulator_model
      )pbdoc");
 }

--- a/kimpy/__init__.py
+++ b/kimpy/__init__.py
@@ -26,7 +26,7 @@ from . import simulator_model
 
 from . import neighlist
 
-from .err import KimPyError, check_error, report_error
+from .err import KimPyError
 
 # needed by `from kimpy import *`
 __all__ = [
@@ -54,6 +54,4 @@ __all__ = [
     'simulator_model',
     'neighlist',
     'KimPyError',
-    'check_error',
-    'report_error',
 ]

--- a/kimpy/callbacks.hpp
+++ b/kimpy/callbacks.hpp
@@ -24,31 +24,35 @@ namespace py = pybind11;
 //  error: int
 //    error code
 //
-int get_neigh(void const * const dataObject,
-              int const numberOfCutoffs,
-              double const * const cutoffs,
-              int const neighborListIndex,
-              int const particleNumber,
-              int * const numberOfNeighbors,
-              int const ** const neighborsOfParticle)
+int get_neigh(void const *const data_object,
+              int const number_of_cutoffs,
+              double const *const cutoffs,
+              int const neighbor_list_index,
+              int const particle_number,
+              int *const number_of_neighbors,
+              int const **const neighbors_of_particle)
 {
   // get python callback function and data
-  auto d1 = const_cast<void *>(dataObject);
+  auto d1 = const_cast<void *>(data_object);
   py::dict d = *(reinterpret_cast<py::dict *>(d1));
   py::object pyfunc = d["pyfunc"];
   py::dict pydata = d["pydata"];
 
   // pack cutoffs as py::array
-  py::array_t<double, py::array::c_style> pycutoffs(numberOfCutoffs);
+  py::array_t<double, py::array::c_style> pycutoffs(number_of_cutoffs);
   auto p_pycutoffs = pycutoffs.mutable_data(0);
-  for (int i = 0; i < numberOfCutoffs; i++) { p_pycutoffs[i] = cutoffs[i]; }
+  for (int i = 0; i < number_of_cutoffs; i++)
+  {
+    p_pycutoffs[i] = cutoffs[i];
+  }
 
   // call python get_neigh function
-  py::tuple out = pyfunc(pydata, pycutoffs, neighborListIndex, particleNumber);
-  auto neigh = static_cast<py::array_t<int> >(out[0]);
+  py::tuple out =
+    pyfunc(pydata, pycutoffs, neighbor_list_index, particle_number);
+  auto neigh = static_cast<py::array_t<int>>(out[0]);
   auto error = out[1].cast<int>();
-  *neighborsOfParticle = neigh.data();
-  *numberOfNeighbors = static_cast<int>(neigh.size());
+  *neighbors_of_particle = neigh.data();
+  *number_of_neighbors = static_cast<int>(neigh.size());
 
   return error;
 }
@@ -74,15 +78,15 @@ int get_neigh(void const * const dataObject,
 //  error: int
 //    error code
 //
-int process_dEdr(void const * const dataObject,
+int process_dEdr(void const *const data_object,
                  double const de,
                  double const r,
-                 double const * const dx,
+                 double const *const dx,
                  int const i,
                  int const j)
 {
   // get python callback function and data
-  auto d1 = const_cast<void *>(dataObject);
+  auto d1 = const_cast<void *>(data_object);
   py::dict d = *(reinterpret_cast<py::dict *>(d1));
   py::object pyfunc = d["pyfunc"];
   py::dict pydata = d["pydata"];
@@ -120,15 +124,15 @@ int process_dEdr(void const * const dataObject,
 //  error: int
 //    error code
 //
-int process_d2Edr2(void const * const dataObject,
+int process_d2Edr2(void const *const data_object,
                    double const de,
-                   double const * const r,
-                   double const * const dx,
-                   int const * const i,
-                   int const * const j)
+                   double const *const r,
+                   double const *const dx,
+                   int const *const i,
+                   int const *const j)
 {
   // get python callback function and data
-  auto d1 = const_cast<void *>(dataObject);
+  auto d1 = const_cast<void *>(data_object);
   py::dict d = *(reinterpret_cast<py::dict *>(d1));
   py::object pyfunc = d["pyfunc"];
   py::dict pydata = d["pydata"];

--- a/kimpy/callbacks.hpp
+++ b/kimpy/callbacks.hpp
@@ -24,13 +24,13 @@ namespace py = pybind11;
 //  error: int
 //    error code
 //
-int get_neigh(void const *const data_object,
+int get_neigh(void const * const data_object,
               int const number_of_cutoffs,
-              double const *const cutoffs,
+              double const * const cutoffs,
               int const neighbor_list_index,
               int const particle_number,
-              int *const number_of_neighbors,
-              int const **const neighbors_of_particle)
+              int * const number_of_neighbors,
+              int const ** const neighbors_of_particle)
 {
   // get python callback function and data
   auto d1 = const_cast<void *>(data_object);
@@ -41,15 +41,12 @@ int get_neigh(void const *const data_object,
   // pack cutoffs as py::array
   py::array_t<double, py::array::c_style> pycutoffs(number_of_cutoffs);
   auto p_pycutoffs = pycutoffs.mutable_data(0);
-  for (int i = 0; i < number_of_cutoffs; i++)
-  {
-    p_pycutoffs[i] = cutoffs[i];
-  }
+  for (int i = 0; i < number_of_cutoffs; i++) { p_pycutoffs[i] = cutoffs[i]; }
 
   // call python get_neigh function
-  py::tuple out =
-    pyfunc(pydata, pycutoffs, neighbor_list_index, particle_number);
-  auto neigh = static_cast<py::array_t<int>>(out[0]);
+  py::tuple out
+      = pyfunc(pydata, pycutoffs, neighbor_list_index, particle_number);
+  auto neigh = static_cast<py::array_t<int> >(out[0]);
   auto error = out[1].cast<int>();
   *neighbors_of_particle = neigh.data();
   *number_of_neighbors = static_cast<int>(neigh.size());
@@ -78,10 +75,10 @@ int get_neigh(void const *const data_object,
 //  error: int
 //    error code
 //
-int process_dEdr(void const *const data_object,
+int process_dEdr(void const * const data_object,
                  double const de,
                  double const r,
-                 double const *const dx,
+                 double const * const dx,
                  int const i,
                  int const j)
 {
@@ -124,12 +121,12 @@ int process_dEdr(void const *const data_object,
 //  error: int
 //    error code
 //
-int process_d2Edr2(void const *const data_object,
+int process_d2Edr2(void const * const data_object,
                    double const de,
-                   double const *const r,
-                   double const *const dx,
-                   int const *const i,
-                   int const *const j)
+                   double const * const r,
+                   double const * const dx,
+                   int const * const i,
+                   int const * const j)
 {
   // get python callback function and data
   auto d1 = const_cast<void *>(data_object);

--- a/kimpy/err.py
+++ b/kimpy/err.py
@@ -18,8 +18,7 @@ class KimPyError(Exception):
 
     def __init__(self, msg):
         """Constuctor."""
-        _msg = '\nERROR(@' + \
-            inspect.currentframe().f_back.f_code.co_name + '): ' + msg
+        _msg = '\nERROR(@' + inspect.currentframe().f_back.f_code.co_name + '): ' + msg
         Exception.__init__(self, _msg)
         self.msg = _msg
 

--- a/kimpy/err.py
+++ b/kimpy/err.py
@@ -4,8 +4,6 @@ import inspect
 
 __all__ = [
     'KimPyError',
-    'check_error',
-    'report_error'
 ]
 
 
@@ -32,25 +30,3 @@ class KimPyError(Exception):
     def __str__(self):
         """Message string representation."""
         return self.msg
-
-
-def check_error(error, message=None):
-    """Check KIM-API return error.
-
-    Args:
-        error (int): 0 indicate everything went well
-        message (str, optional): error message. Defaults to None.
-    """
-    if error != 0 and error is not None:
-        msg = 'KIM error. Calling "{}" failed.'.format(message)
-        raise KimPyError(msg)
-
-
-def report_error(message=None):
-    """Check KIM-API return error.
-
-    Args:
-        message (str, optional): error message. Defaults to None.
-    """
-    msg = 'KIM error. {}.'.format(message)
-    raise KimPyError(msg)

--- a/kimpy/neighlist/helper.hpp
+++ b/kimpy/neighlist/helper.hpp
@@ -9,13 +9,6 @@
 
 #define SMALL 1.0e-10
 
-#define MY_ERROR(message)                                             \
-  {                                                                   \
-    std::cerr << "* Error (Neighbor List): \"" << message             \
-              << "\" : " << __LINE__ << ":" << __FILE__ << std::endl; \
-    std::exit(1);                                                     \
-  }
-
 #define MY_WARNING(message)                                           \
   {                                                                   \
     std::cerr << "* Error (Neighbor List) : \"" << message            \
@@ -23,21 +16,21 @@
   }
 
 // norm of a 3-element vector
-inline double norm(double const * a)
+inline double norm(double const *a)
 {
   return std::sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
 }
 
 
 // dot product of two 3-element vectors
-inline double dot(double const * a, double const * b)
+inline double dot(double const *a, double const *b)
 {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
 
 // cross product of two 3-element vectors
-inline void cross(double const * a, double const * b, double * const axb)
+inline void cross(double const *a, double const *b, double *const axb)
 {
   axb[0] = a[1] * b[2] - a[2] * b[1];
   axb[1] = a[2] * b[0] - a[0] * b[2];
@@ -46,7 +39,7 @@ inline void cross(double const * a, double const * b, double * const axb)
 
 
 // determinant of a 3 by 3 matrix
-inline double det(double const * mat)
+inline double det(double const *mat)
 {
   return mat[0] * mat[4] * mat[8] - mat[0] * mat[5] * mat[7]
          - mat[1] * mat[3] * mat[8] + mat[1] * mat[5] * mat[6]
@@ -62,17 +55,22 @@ inline double det2(double a11, double a12, double a21, double a22)
 
 
 // transpose of a 3 by 3 matrix
-inline void transpose(double const * mat, double * const trans)
+inline void transpose(double const *mat, double *const trans)
 {
-  for (int i = 0; i < 3; i++)
-  {
-    for (int j = 0; j < 3; j++) { trans[3 * i + j] = mat[3 * j + i]; }
-  }
+  trans[0] = mat[0];
+  trans[1] = mat[3];
+  trans[2] = mat[6];
+  trans[3] = mat[1];
+  trans[4] = mat[4];
+  trans[5] = mat[7];
+  trans[6] = mat[2];
+  trans[7] = mat[5];
+  trans[8] = mat[8];
 }
 
 
 // inverse of a 3 by 3 matrix
-inline int inverse(double const * mat, double * const inv)
+inline int inverse(double const *mat, double *const inv)
 {
   inv[0] = det2(mat[4], mat[5], mat[7], mat[8]);
   inv[1] = det2(mat[2], mat[1], mat[8], mat[7]);
@@ -84,7 +82,7 @@ inline int inverse(double const * mat, double * const inv)
   inv[7] = det2(mat[1], mat[0], mat[7], mat[6]);
   inv[8] = det2(mat[0], mat[1], mat[3], mat[4]);
 
-  double dd = det(mat);
+  double const dd = det(mat);
   if (std::abs(dd) < SMALL)
   {
     MY_WARNING("Cannot invert cell matrix. Determinant is 0.");
@@ -95,20 +93,18 @@ inline int inverse(double const * mat, double * const inv)
 }
 
 
-inline void coords_to_index(double const * x,
-                            int const * size,
-                            double const * max,
-                            double const * min,
-                            int * const index)
+inline void coords_to_index(double const *x,
+                            int const *size,
+                            double const *max,
+                            double const *min,
+                            int *const index)
 {
-  for (int i = 0; i < 3; i++)
-  {
-    index[i]
-        = static_cast<int>(((x[i] - min[i]) / (max[i] - min[i])) * size[i]);
-    index[i] = std::min(index[i],
-                        size[i] - 1);  // handle edge case when x[i] = max[i]
-  }
+  index[0] = static_cast<int>(((x[0] - min[0]) / (max[0] - min[0])) * size[0]);
+  index[0] = std::min(index[0], size[0] - 1); // edge case when x[0] = max[0]
+  index[1] = static_cast<int>(((x[1] - min[1]) / (max[1] - min[1])) * size[1]);
+  index[1] = std::min(index[1], size[1] - 1); // edge case when x[1] = max[1]
+  index[2] = static_cast<int>(((x[2] - min[2]) / (max[2] - min[2])) * size[2]);
+  index[2] = std::min(index[2], size[2] - 1); // edge case when x[2] = max[2]
 }
 
-
-#endif
+#endif // HELPER_HPP_

--- a/kimpy/neighlist/helper.hpp
+++ b/kimpy/neighlist/helper.hpp
@@ -16,21 +16,21 @@
   }
 
 // norm of a 3-element vector
-inline double norm(double const *a)
+inline double norm(double const * a)
 {
   return std::sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
 }
 
 
 // dot product of two 3-element vectors
-inline double dot(double const *a, double const *b)
+inline double dot(double const * a, double const * b)
 {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
 
 // cross product of two 3-element vectors
-inline void cross(double const *a, double const *b, double *const axb)
+inline void cross(double const * a, double const * b, double * const axb)
 {
   axb[0] = a[1] * b[2] - a[2] * b[1];
   axb[1] = a[2] * b[0] - a[0] * b[2];
@@ -39,7 +39,7 @@ inline void cross(double const *a, double const *b, double *const axb)
 
 
 // determinant of a 3 by 3 matrix
-inline double det(double const *mat)
+inline double det(double const * mat)
 {
   return mat[0] * mat[4] * mat[8] - mat[0] * mat[5] * mat[7]
          - mat[1] * mat[3] * mat[8] + mat[1] * mat[5] * mat[6]
@@ -55,7 +55,7 @@ inline double det2(double a11, double a12, double a21, double a22)
 
 
 // transpose of a 3 by 3 matrix
-inline void transpose(double const *mat, double *const trans)
+inline void transpose(double const * mat, double * const trans)
 {
   trans[0] = mat[0];
   trans[1] = mat[3];
@@ -70,7 +70,7 @@ inline void transpose(double const *mat, double *const trans)
 
 
 // inverse of a 3 by 3 matrix
-inline int inverse(double const *mat, double *const inv)
+inline int inverse(double const * mat, double * const inv)
 {
   inv[0] = det2(mat[4], mat[5], mat[7], mat[8]);
   inv[1] = det2(mat[2], mat[1], mat[8], mat[7]);
@@ -93,18 +93,18 @@ inline int inverse(double const *mat, double *const inv)
 }
 
 
-inline void coords_to_index(double const *x,
-                            int const *size,
-                            double const *max,
-                            double const *min,
-                            int *const index)
+inline void coords_to_index(double const * x,
+                            int const * size,
+                            double const * max,
+                            double const * min,
+                            int * const index)
 {
   index[0] = static_cast<int>(((x[0] - min[0]) / (max[0] - min[0])) * size[0]);
-  index[0] = std::min(index[0], size[0] - 1); // edge case when x[0] = max[0]
+  index[0] = std::min(index[0], size[0] - 1);  // edge case when x[0] = max[0]
   index[1] = static_cast<int>(((x[1] - min[1]) / (max[1] - min[1])) * size[1]);
-  index[1] = std::min(index[1], size[1] - 1); // edge case when x[1] = max[1]
+  index[1] = std::min(index[1], size[1] - 1);  // edge case when x[1] = max[1]
   index[2] = static_cast<int>(((x[2] - min[2]) / (max[2] - min[2])) * size[2]);
-  index[2] = std::min(index[2], size[2] - 1); // edge case when x[2] = max[2]
+  index[2] = std::min(index[2], size[2] - 1);  // edge case when x[2] = max[2]
 }
 
-#endif // HELPER_HPP_
+#endif  // HELPER_HPP_

--- a/kimpy/neighlist/neighbor_list.cpp
+++ b/kimpy/neighlist/neighbor_list.cpp
@@ -152,7 +152,7 @@ int nbl_build(NeighList * const nl,
   }
 
   // temporary neigh container
-  std::vector<int> * tmp_neigh = new std::vector<int>[numberOfCutoffs];
+  std::vector<std::vector<int> > tmp_neigh(numberOfCutoffs);
   std::vector<int> total(numberOfCutoffs, 0);
   std::vector<int> num_neigh(numberOfCutoffs);
 
@@ -236,8 +236,6 @@ int nbl_build(NeighList * const nl,
     std::memcpy(
         nl->lists[k].neighborList, tmp_neigh[k].data(), sizeof(int) * total[k]);
   }
-
-  delete[] tmp_neigh;
 
   return 0;
 }

--- a/kimpy/neighlist/neighbor_list.cpp
+++ b/kimpy/neighlist/neighbor_list.cpp
@@ -12,7 +12,7 @@
 #define TOL 1.0e-10
 
 
-void nbl_clean_content(NeighList *const nl)
+void nbl_clean_content(NeighList * const nl)
 {
   if (nl)
   {
@@ -20,7 +20,7 @@ void nbl_clean_content(NeighList *const nl)
     {
       for (int i = 0; i < nl->numberOfNeighborLists; i++)
       {
-        NeighListOne *cnl = &(nl->lists[i]);
+        NeighListOne * cnl = &(nl->lists[i]);
         if (cnl->Nneighbors) delete[] cnl->Nneighbors;
         if (cnl->neighborList) delete[] cnl->neighborList;
         if (cnl->beginIndex) delete[] cnl->beginIndex;
@@ -38,7 +38,7 @@ void nbl_clean_content(NeighList *const nl)
 }
 
 
-void nbl_allocate_memory(NeighList *const nl,
+void nbl_allocate_memory(NeighList * const nl,
                          int const numberOfCutoffs,
                          int const numberOfParticles)
 {
@@ -48,7 +48,7 @@ void nbl_allocate_memory(NeighList *const nl,
     nl->numberOfNeighborLists = numberOfCutoffs;
     for (int i = 0; i < numberOfCutoffs; i++)
     {
-      NeighListOne *cnl = &(nl->lists[i]);
+      NeighListOne * cnl = &(nl->lists[i]);
       cnl->Nneighbors = new int[numberOfParticles];
       cnl->beginIndex = new int[numberOfParticles];
     }
@@ -56,13 +56,10 @@ void nbl_allocate_memory(NeighList *const nl,
 }
 
 
-void nbl_initialize(NeighList **const nl)
-{
-  *nl = new NeighList;
-}
+void nbl_initialize(NeighList ** const nl) { *nl = new NeighList; }
 
 
-void nbl_clean(NeighList **const nl)
+void nbl_clean(NeighList ** const nl)
 {
   if (*nl)
   {
@@ -76,13 +73,13 @@ void nbl_clean(NeighList **const nl)
 }
 
 
-int nbl_build(NeighList *const nl,
+int nbl_build(NeighList * const nl,
               int const numberOfParticles,
-              double const *coordinates,
+              double const * coordinates,
               double const influenceDistance,
               int const numberOfCutoffs,
-              double const *cutoffs,
-              int const *needNeighbors)
+              double const * cutoffs,
+              int const * needNeighbors)
 {
   // find max and min extend of coordinates
   double min[3];
@@ -99,14 +96,14 @@ int nbl_build(NeighList *const nl,
 
   for (int i = 0, l = 0; i < numberOfParticles; i++)
   {
-    if (max[0] < coordinates[l]) {max[0] = coordinates[l]; }
-    if (min[0] > coordinates[l]) {min[0] = coordinates[l]; }
+    if (max[0] < coordinates[l]) { max[0] = coordinates[l]; }
+    if (min[0] > coordinates[l]) { min[0] = coordinates[l]; }
     ++l;
-    if (max[1] < coordinates[l]) {max[1] = coordinates[l]; }
-    if (min[1] > coordinates[l]) {min[1] = coordinates[l]; }
+    if (max[1] < coordinates[l]) { max[1] = coordinates[l]; }
+    if (min[1] > coordinates[l]) { min[1] = coordinates[l]; }
     ++l;
-    if (max[2] < coordinates[l]) {max[2] = coordinates[l]; }
-    if (min[2] > coordinates[l]) {min[2] = coordinates[l]; }
+    if (max[2] < coordinates[l]) { max[2] = coordinates[l]; }
+    if (min[2] > coordinates[l]) { min[2] = coordinates[l]; }
     ++l;
   }
 
@@ -129,15 +126,15 @@ int nbl_build(NeighList *const nl,
   }
 
   // assign atoms into cells
-  std::vector<std::vector<int>> cells(size_total);
+  std::vector<std::vector<int> > cells(size_total);
   for (int i = 0; i < numberOfParticles; i++)
   {
     int index[3];
 
     coords_to_index(&coordinates[3 * i], size, max, min, index);
 
-    int const idx =
-      index[0] + index[1] * size[0] + index[2] * size[0] * size[1];
+    int const idx
+        = index[0] + index[1] * size[0] + index[2] * size[0] * size[1];
 
     cells[idx].push_back(i);
   }
@@ -155,7 +152,7 @@ int nbl_build(NeighList *const nl,
   }
 
   // temporary neigh container
-  std::vector<int> *tmp_neigh = new std::vector<int>[numberOfCutoffs];
+  std::vector<int> * tmp_neigh = new std::vector<int>[numberOfCutoffs];
   std::vector<int> total(numberOfCutoffs, 0);
   std::vector<int> num_neigh(numberOfCutoffs);
 
@@ -237,8 +234,7 @@ int nbl_build(NeighList *const nl,
     nl->lists[k].cutoff = cutoffs[k];
     nl->lists[k].neighborList = new int[total[k]];
     std::memcpy(
-        nl->lists[k].neighborList,
-        tmp_neigh[k].data(), sizeof(int) * total[k]);
+        nl->lists[k].neighborList, tmp_neigh[k].data(), sizeof(int) * total[k]);
   }
 
   delete[] tmp_neigh;
@@ -247,19 +243,19 @@ int nbl_build(NeighList *const nl,
 }
 
 
-int nbl_get_neigh(void const *const dataObject,
+int nbl_get_neigh(void const * const dataObject,
                   int const numberOfCutoffs,
-                  double const *const cutoffs,
+                  double const * const cutoffs,
                   int const neighborListIndex,
                   int const particleNumber,
-                  int *const numberOfNeighbors,
-                  int const **const neighborsOfParticle)
+                  int * const numberOfNeighbors,
+                  int const ** const neighborsOfParticle)
 {
-  NeighList *nl = (NeighList *) dataObject;
+  NeighList * nl = (NeighList *) dataObject;
 
   if (neighborListIndex >= nl->numberOfNeighborLists) { return 1; }
 
-  NeighListOne *cnl = &(nl->lists[neighborListIndex]);
+  NeighListOne * cnl = &(nl->lists[neighborListIndex]);
 
   if (cutoffs[neighborListIndex] > cnl->cutoff + TOL) { return 1; }
 
@@ -286,14 +282,14 @@ int nbl_get_neigh(void const *const dataObject,
 
 int nbl_create_paddings(int const numberOfParticles,
                         double const cutoff,
-                        double const *cell,
-                        int const *PBC,
-                        double const *coordinates,
-                        int const *speciesCode,
-                        int &numberOfPaddings,
-                        std::vector<double> &coordinatesOfPaddings,
-                        std::vector<int> &speciesCodeOfPaddings,
-                        std::vector<int> &masterOfPaddings)
+                        double const * cell,
+                        int const * PBC,
+                        double const * coordinates,
+                        int const * speciesCode,
+                        int & numberOfPaddings,
+                        std::vector<double> & coordinatesOfPaddings,
+                        std::vector<int> & speciesCodeOfPaddings,
+                        std::vector<int> & masterOfPaddings)
 {
   // transform coordinates into fractional coordinates
   double tcell[9];
@@ -311,7 +307,7 @@ int nbl_create_paddings(int const numberOfParticles,
 
   for (int i = 0; i < numberOfParticles; i++)
   {
-    const double *atom_coords = coordinates + (3 * i);
+    const double * atom_coords = coordinates + (3 * i);
 
     double x = dot(fcell, atom_coords);
     double y = dot(fcell + 3, atom_coords);
@@ -357,20 +353,16 @@ int nbl_create_paddings(int const numberOfParticles,
   dist[2] = volume / norm(xprod);
 
   // number of cells in each direction
-  double const ratio[3] = {cutoff / dist[0],
-                           cutoff / dist[1],
-                           cutoff / dist[2]};
+  double const ratio[3]
+      = {cutoff / dist[0], cutoff / dist[1], cutoff / dist[2]};
 
   int const size[3] = {static_cast<int>(std::ceil(ratio[0])),
                        static_cast<int>(std::ceil(ratio[1])),
                        static_cast<int>(std::ceil(ratio[2]))};
 
-  double const size_ratio_diff_x =
-    static_cast<double>(size[0]) - ratio[0];
-  double const size_ratio_diff_y =
-    static_cast<double>(size[1]) - ratio[1];
-  double const size_ratio_diff_z =
-    static_cast<double>(size[2]) - ratio[2];
+  double const size_ratio_diff_x = static_cast<double>(size[0]) - ratio[0];
+  double const size_ratio_diff_y = static_cast<double>(size[1]) - ratio[1];
+  double const size_ratio_diff_z = static_cast<double>(size[2]) - ratio[2];
 
 
   // creating padding atoms

--- a/kimpy/neighlist/neighbor_list.h
+++ b/kimpy/neighlist/neighbor_list.h
@@ -9,47 +9,47 @@ struct NeighListOne
 {
   int numberOfParticles = 0;
   double cutoff = 0.0;
-  int *Nneighbors = nullptr;
-  int *neighborList = nullptr;
-  int *beginIndex = nullptr;
+  int * Nneighbors = nullptr;
+  int * neighborList = nullptr;
+  int * beginIndex = nullptr;
 };
 
 // neighbor list structure
 struct NeighList
 {
   int numberOfNeighborLists = 0;
-  NeighListOne *lists = nullptr;
+  NeighListOne * lists = nullptr;
 };
 
-void nbl_initialize(NeighList **const nl);
+void nbl_initialize(NeighList ** const nl);
 
 int nbl_create_paddings(int const numberOfParticles,
                         double const cutoff,
-                        double const *cell,
-                        int const *PBC,
-                        double const *coordinates,
-                        int const *speciesCode,
-                        int &numberOfPaddings,
-                        std::vector<double> &coordinatesOfPaddings,
-                        std::vector<int> &speciesCodeOfPaddings,
-                        std::vector<int> &masterOfPaddings);
+                        double const * cell,
+                        int const * PBC,
+                        double const * coordinates,
+                        int const * speciesCode,
+                        int & numberOfPaddings,
+                        std::vector<double> & coordinatesOfPaddings,
+                        std::vector<int> & speciesCodeOfPaddings,
+                        std::vector<int> & masterOfPaddings);
 
-int nbl_build(NeighList *const nl,
+int nbl_build(NeighList * const nl,
               int const numberOfParticles,
-              double const *coordinates,
+              double const * coordinates,
               double const influenceDistance,
               int const numberOfCutoffs,
-              double const *cutoffs,
-              int const *needNeighbors);
+              double const * cutoffs,
+              int const * needNeighbors);
 
-int nbl_get_neigh(void const *const nl,
+int nbl_get_neigh(void const * const nl,
                   int const numberOfCutoffs,
-                  double const *const cutoffs,
+                  double const * const cutoffs,
                   int const neighborListIndex,
                   int const particleNumber,
-                  int *const numberOfNeighbors,
-                  int const **const neighborsOfParticle);
+                  int * const numberOfNeighbors,
+                  int const ** const neighborsOfParticle);
 
-void nbl_clean(NeighList **const nl);
+void nbl_clean(NeighList ** const nl);
 
-#endif // NEIGHBOR_LIST_H_
+#endif  // NEIGHBOR_LIST_H_

--- a/kimpy/neighlist/neighbor_list.h
+++ b/kimpy/neighlist/neighbor_list.h
@@ -9,49 +9,47 @@ struct NeighListOne
 {
   int numberOfParticles = 0;
   double cutoff = 0.0;
-  int * Nneighbors = nullptr;
-  int * neighborList = nullptr;
-  int * beginIndex = nullptr;
+  int *Nneighbors = nullptr;
+  int *neighborList = nullptr;
+  int *beginIndex = nullptr;
 };
 
 // neighbor list structure
 struct NeighList
 {
   int numberOfNeighborLists = 0;
-  NeighListOne * lists = nullptr;
+  NeighListOne *lists = nullptr;
 };
 
-
-void nbl_initialize(NeighList ** const nl);
+void nbl_initialize(NeighList **const nl);
 
 int nbl_create_paddings(int const numberOfParticles,
                         double const cutoff,
-                        double const * cell,
-                        int const * PBC,
-                        double const * coordinates,
-                        int const * speciesCode,
-                        int & numberOfPaddings,
-                        std::vector<double> & coordinatesOfPaddings,
-                        std::vector<int> & speciesCodeOfPaddings,
-                        std::vector<int> & masterOfPaddings);
+                        double const *cell,
+                        int const *PBC,
+                        double const *coordinates,
+                        int const *speciesCode,
+                        int &numberOfPaddings,
+                        std::vector<double> &coordinatesOfPaddings,
+                        std::vector<int> &speciesCodeOfPaddings,
+                        std::vector<int> &masterOfPaddings);
 
-int nbl_build(NeighList * const nl,
+int nbl_build(NeighList *const nl,
               int const numberOfParticles,
-              double const * coordinates,
+              double const *coordinates,
               double const influenceDistance,
               int const numberOfCutoffs,
-              double const * cutoffs,
-              int const * needNeighbors);
+              double const *cutoffs,
+              int const *needNeighbors);
 
-int nbl_get_neigh(void const * const nl,
+int nbl_get_neigh(void const *const nl,
                   int const numberOfCutoffs,
-                  double const * const cutoffs,
+                  double const *const cutoffs,
                   int const neighborListIndex,
                   int const particleNumber,
-                  int * const numberOfNeighbors,
-                  int const ** const neighborsOfParticle);
+                  int *const numberOfNeighbors,
+                  int const **const neighborsOfParticle);
 
-void nbl_clean(NeighList ** const nl);
+void nbl_clean(NeighList **const nl);
 
-
-#endif
+#endif // NEIGHBOR_LIST_H_

--- a/kimpy/neighlist/neighbor_list_bind.cpp
+++ b/kimpy/neighlist/neighbor_list_bind.cpp
@@ -38,7 +38,7 @@ PYBIND11_MODULE(neighlist, module)
        Create a new NeighList object.
 
        Returns:
-           neighList
+           NeighList: neighList
        )pbdoc");
 
   module.def("initialize", []() {
@@ -52,7 +52,7 @@ PYBIND11_MODULE(neighlist, module)
        Create a new NeighList object.
 
        Returns:
-           neighList
+           NeighList: neighList
        )pbdoc");
 
   module.def("build",

--- a/kimpy/neighlist/neighbor_list_bind.cpp
+++ b/kimpy/neighlist/neighbor_list_bind.cpp
@@ -11,89 +11,100 @@
 namespace py = pybind11;
 
 
-namespace {
-struct PyNeighListDestroy {
-  void operator()(NeighList *neighList) const {
-    nbl_clean(&neighList);
-  }
+namespace
+{
+struct PyNeighListDestroy
+{
+  void operator()(NeighList * neighList) const { nbl_clean(&neighList); }
 };
-} // namespace
+}  // namespace
 
 
 PYBIND11_MODULE(neighlist, module)
 {
   module.doc() = "Python binding to neighbor list.";
 
-  py::class_<NeighList, std::unique_ptr<NeighList, PyNeighListDestroy>>(
-    module, "NeighList", py::module_local()).def(py::init());
+  py::class_<NeighList, std::unique_ptr<NeighList, PyNeighListDestroy> >(
+      module, "NeighList", py::module_local())
+      .def(py::init());
 
-  module.def("create", []() {
-      NeighList *neighList;
+  module
+      .def(
+          "create",
+          []() {
+    NeighList * neighList;
 
-      nbl_initialize(&neighList);
+    nbl_initialize(&neighList);
 
-      return std::unique_ptr<NeighList, PyNeighListDestroy>(
-        std::move(neighList));
-    }, R"pbdoc(
-       Create a new NeighList object.
+    return std::unique_ptr<NeighList, PyNeighListDestroy>(std::move(neighList));
+          }, R"pbdoc(
+             Create a new NeighList object.
 
-       Returns:
-           NeighList: neighList
-       )pbdoc");
+             Returns:
+                 NeighList: neighList
+             )pbdoc"
+          );
 
-  module.def("initialize", []() {
-      NeighList *neighList;
+      module
+      .def(
+          "initialize",
+          []() {
+    NeighList * neighList;
 
-      nbl_initialize(&neighList);
+    nbl_initialize(&neighList);
 
-      return std::unique_ptr<NeighList, PyNeighListDestroy>(
-        std::move(neighList));
-    }, R"pbdoc(
-       Create a new NeighList object.
+    return std::unique_ptr<NeighList, PyNeighListDestroy>(std::move(neighList));
+          }, R"pbdoc(
+             Create a new NeighList object.
 
-       Returns:
-           NeighList: neighList
-       )pbdoc");
+             Returns:
+                 NeighList: neighList
+             )pbdoc"
+          );
 
-  module.def("build",
-             [](NeighList *const neighList,
-                py::array_t<double> coords,
-                double const influenceDistance,
-                py::array_t<double> cutoffs,
-                py::array_t<int> need_neigh) {
-    int Natoms_1 = static_cast<int>(coords.size() / 3);
-    int Natoms_2 = static_cast<int>(need_neigh.size());
+      module.def(
+          "build",
+          [](NeighList * const neighList,
+             py::array_t<double> coords,
+             double const influenceDistance,
+             py::array_t<double> cutoffs,
+             py::array_t<int> need_neigh) {
+            int Natoms_1 = static_cast<int>(coords.size() / 3);
+            int Natoms_2 = static_cast<int>(need_neigh.size());
 
-    if (Natoms_1 != Natoms_2) {
-      throw std::runtime_error(
-        "\"coords\" size and \"need_neigh\" size do not match!");
-    }
+            if (Natoms_1 != Natoms_2)
+            {
+              throw std::runtime_error(
+                  "\"coords\" size and \"need_neigh\" size do not match!");
+            }
 
-    int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
+            int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
 
-    double const *c = coords.data();
-    int numberOfCutoffs = static_cast<int>(cutoffs.size());
-    double const *pcutoffs = cutoffs.data();
-    int const *nn = need_neigh.data();
+            double const * c = coords.data();
+            int numberOfCutoffs = static_cast<int>(cutoffs.size());
+            double const * pcutoffs = cutoffs.data();
+            int const * nn = need_neigh.data();
 
-    int error = nbl_build(neighList,
-                          Natoms,
-                          c,
-                          influenceDistance,
-                          numberOfCutoffs,
-                          pcutoffs,
-                          nn);
-    if (error == 1) {
-      throw std::runtime_error(
-        "Cell size too large! (partilces fly away) or\n"
-        "Collision of atoms happened!");
-    }
-  }, "Build neighList.",
-     py::arg("neighList"),
-     py::arg("coords").noconvert(),
-     py::arg("influenceDistance"),
-     py::arg("cutoffs").noconvert(),
-     py::arg("need_neigh").noconvert());
+            int error = nbl_build(neighList,
+                                  Natoms,
+                                  c,
+                                  influenceDistance,
+                                  numberOfCutoffs,
+                                  pcutoffs,
+                                  nn);
+            if (error == 1)
+            {
+              throw std::runtime_error(
+                  "Cell size too large! (partilces fly away) or\n"
+                  "Collision of atoms happened!");
+            }
+          },
+          "Build neighList.",
+          py::arg("neighList"),
+          py::arg("coords").noconvert(),
+          py::arg("influenceDistance"),
+          py::arg("cutoffs").noconvert(),
+          py::arg("need_neigh").noconvert());
 
   module.def("get_neigh",
              [](NeighList const *const neighList,
@@ -101,9 +112,9 @@ PYBIND11_MODULE(neighlist, module)
                 int const neighborListIndex,
                 int const particleNumber) {
     int numberOfCutoffs = static_cast<int>(cutoffs.size());
-    double const *pcutoffs = cutoffs.data();
+    double const * pcutoffs = cutoffs.data();
     int numberOfNeighbors = 0;
-    int const *neighOfAtom;
+    int const * neighOfAtom;
 
     int error = nbl_get_neigh(neighList,
                               numberOfCutoffs,
@@ -112,38 +123,37 @@ PYBIND11_MODULE(neighlist, module)
                               particleNumber,
                               &numberOfNeighbors,
                               &neighOfAtom);
-    if (error == 1) {
+    if (error == 1)
+    {
       throw std::runtime_error(
-        "neighborListIndex >= neighList->numberOfNeighborLists!  or\n"
-        "cutoffs[neighborListIndex] > "
-        "neighList->lists[neighborListIndex]->cutoff!  or\n"
-        "particleNumber >= numberOfParticles!  or\n"
-        "particleNumber < 0!");
+          "neighborListIndex >= neighList->numberOfNeighborLists!  or\n"
+          "cutoffs[neighborListIndex] > "
+          "neighList->lists[neighborListIndex]->cutoff!  or\n"
+          "particleNumber >= numberOfParticles!  or\n"
+          "particleNumber < 0!");
     }
 
     // pack as a numpy array
-    auto neighborsOfParticle =
-      py::array(
-        py::buffer_info(
-          const_cast<int *>(neighOfAtom),        // data pointer
-          sizeof(int),                           // size of one element
-          py::format_descriptor<int>::format(),  // Python struct-style
-                                                 // format descriptor
-          1,                                     // dimension
-          {numberOfNeighbors},                   // size of each dimension
-          {sizeof(int)}                          // stride of each dimension
-      ));
+    auto neighborsOfParticle = py::array(py::buffer_info(
+        const_cast<int *>(neighOfAtom),  // data pointer
+        sizeof(int),  // size of one element
+        py::format_descriptor<int>::format(),  // Python struct-style
+                                               // format descriptor
+        1,  // dimension
+        {numberOfNeighbors},  // size of each dimension
+        {sizeof(int)}  // stride of each dimension
+        ));
 
     py::tuple re(2);
     re[0] = numberOfNeighbors;
     re[1] = neighborsOfParticle;
     return re;
   }, R"pbdoc(
-       Get the neighList's numberOfNeighbors and neighborsOfParticle.
+     Get the neighList's numberOfNeighbors and neighborsOfParticle.
 
-       Returns:
-           int, 1darray: numberOfNeighbors, neighborsOfParticle
-       )pbdoc",
+     Returns:
+         int, 1darray: numberOfNeighbors, neighborsOfParticle
+     )pbdoc",
      py::arg("neighList"),
      py::arg("cutoffs").noconvert(),
      py::arg("neighborListIndex"),
@@ -167,17 +177,18 @@ PYBIND11_MODULE(neighlist, module)
     int Natoms_1 = static_cast<int>(coords.size() / 3);
     int Natoms_2 = static_cast<int>(species.size());
 
-    if (Natoms_1 != Natoms_2) {
+    if (Natoms_1 != Natoms_2)
+    {
       throw std::runtime_error(
           "\"coords\" size and \"species\" size do not match!");
     }
 
     int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
 
-    double const *cell2 = cell.data();
-    int const *PBC2 = PBC.data();
-    double const *coords2 = coords.data();
-    int const *species2 = species.data();
+    double const * cell2 = cell.data();
+    int const * PBC2 = PBC.data();
+    double const * coords2 = coords.data();
+    int const * species2 = species.data();
 
     int Npad;
     std::vector<double> pad_coords;
@@ -194,37 +205,38 @@ PYBIND11_MODULE(neighlist, module)
                                     pad_coords,
                                     pad_species,
                                     pad_image);
-    if (error == 1) {
+    if (error == 1)
+    {
       throw std::runtime_error(
           "In inverting the cell matrix, the determinant is 0!");
     }
 
     // pack as a 2D numpy array
-    auto coordinates_of_paddings =
-      py::array(py::buffer_info(pad_coords.data(),
-                                sizeof(double),
-                                py::format_descriptor<double>::format(),
-                                2,
-                                {Npad, 3},
-                                {sizeof(double) *3, sizeof(double)}));
+    auto coordinates_of_paddings
+        = py::array(py::buffer_info(pad_coords.data(),
+                                    sizeof(double),
+                                    py::format_descriptor<double>::format(),
+                                    2,
+                                    {Npad, 3},
+                                    {sizeof(double) * 3, sizeof(double)}));
 
     // pack as a numpy array
-    auto species_code_of_paddings =
-      py::array(py::buffer_info(pad_species.data(),
-                                sizeof(int),
-                                py::format_descriptor<int>::format(),
-                                1,
-                                {Npad},
-                                {sizeof(int)}));
+    auto species_code_of_paddings
+        = py::array(py::buffer_info(pad_species.data(),
+                                    sizeof(int),
+                                    py::format_descriptor<int>::format(),
+                                    1,
+                                    {Npad},
+                                    {sizeof(int)}));
 
     // pack as a numpy array
-    auto master_particle_of_paddings =
-      py::array(py::buffer_info(pad_image.data(),
-                                sizeof(int),
-                                py::format_descriptor<int>::format(),
-                                1,
-                                {Npad},
-                                {sizeof(int)}));
+    auto master_particle_of_paddings
+        = py::array(py::buffer_info(pad_image.data(),
+                                    sizeof(int),
+                                    py::format_descriptor<int>::format(),
+                                    1,
+                                    {Npad},
+                                    {sizeof(int)}));
 
     py::tuple re(3);
     re[0] = coordinates_of_paddings;

--- a/kimpy/neighlist/neighbor_list_bind.cpp
+++ b/kimpy/neighlist/neighbor_list_bind.cpp
@@ -34,8 +34,12 @@ PYBIND11_MODULE(neighlist, module)
 
       return std::unique_ptr<NeighList, PyNeighListDestroy>(
         std::move(neighList));
-    }, "Create a new NeighList object.",
-       "Return neighList");
+    }, R"pbdoc(
+       Create a new NeighList object.
+
+       Returns:
+           neighList
+       )pbdoc");
 
   module.def("initialize", []() {
       NeighList *neighList;
@@ -44,8 +48,12 @@ PYBIND11_MODULE(neighlist, module)
 
       return std::unique_ptr<NeighList, PyNeighListDestroy>(
         std::move(neighList));
-    }, "Create a new NeighList object.",
-       "Return neighList");
+    }, R"pbdoc(
+       Create a new NeighList object.
+
+       Returns:
+           neighList
+       )pbdoc");
 
   module.def("build",
              [](NeighList *const neighList,
@@ -130,12 +138,16 @@ PYBIND11_MODULE(neighlist, module)
     re[0] = numberOfNeighbors;
     re[1] = neighborsOfParticle;
     return re;
-  }, "Get the neighList's numberOfNeighbors and neighborsOfParticle.",
+  }, R"pbdoc(
+       Get the neighList's numberOfNeighbors and neighborsOfParticle.
+
+       Returns:
+           int, 1darray: numberOfNeighbors, neighborsOfParticle
+       )pbdoc",
      py::arg("neighList"),
      py::arg("cutoffs").noconvert(),
      py::arg("neighborListIndex"),
-     py::arg("particleNumber"),
-     "Return(numberOfNeighbors, neighborsOfParticle)");
+     py::arg("particleNumber"));
 
   // cannot bind `nbl_get_neigh_kim` directly, since it has pointer arguments
   // so we return a pointer to this function
@@ -219,12 +231,16 @@ PYBIND11_MODULE(neighlist, module)
     re[1] = species_code_of_paddings;
     re[2] = master_particle_of_paddings;
     return re;
-  }, "Create padding.",
+  }, R"pbdoc(
+     Create padding.
+
+     Returns:
+         2darray, 1darray, 1darray: coordinates_of_paddings,
+             species_code_of_paddings, master_particle_of_paddings
+     )pbdoc",
      py::arg("influenceDistance"),
      py::arg("cell").noconvert(),
      py::arg("PBC").noconvert(),
      py::arg("coords").noconvert(),
-     py::arg("species").noconvert(),
-     "Return(coordinates_of_paddings, species_code_of_paddings, "
-     "master_particle_of_paddings)");
+     py::arg("species").noconvert());
 }

--- a/kimpy/neighlist/neighbor_list_bind.cpp
+++ b/kimpy/neighlist/neighbor_list_bind.cpp
@@ -8,6 +8,12 @@
 #include <memory>
 #include <vector>
 
+#define MY_WARNING(message)                                           \
+  {                                                                   \
+    std::cerr << "* Error (Neighbor List) : \"" << message            \
+              << "\" : " << __LINE__ << ":" << __FILE__ << std::endl; \
+  }
+
 namespace py = pybind11;
 
 
@@ -26,138 +32,248 @@ PYBIND11_MODULE(neighlist, module)
 
   py::class_<NeighList, std::unique_ptr<NeighList, PyNeighListDestroy> >(
       module, "NeighList", py::module_local())
-      .def(py::init());
-
-  module
-      .def(
-          "create",
-          []() {
-    NeighList * neighList;
-
-    nbl_initialize(&neighList);
-
+      .def(py::init([]() {
+    NeighList * neighList = new NeighList;
     return std::unique_ptr<NeighList, PyNeighListDestroy>(std::move(neighList));
-          }, R"pbdoc(
-             Create a new NeighList object.
+      }))
+      .def("build",
+           [](NeighList &self,
+              py::array_t<double> coords,
+              double const influence_distance,
+              py::array_t<double> cutoffs,
+              py::array_t<int> need_neigh) {
+    int const natoms_1 = static_cast<int>(coords.size() / 3);
+    int const natoms_2 = static_cast<int>(need_neigh.size());
 
-             Returns:
-                 NeighList: neighList
-             )pbdoc"
-          );
+    if (natoms_1 != natoms_2)
+    {
+      MY_WARNING("\"coords\" size and \"need_neigh\" size do not match!");
+    }
 
-      module
-      .def(
-          "initialize",
-          []() {
-    NeighList * neighList;
+    int const natoms = natoms_1 <= natoms_2 ? natoms_1 : natoms_2;
+    double const * coords_data = coords.data();
+    int const number_of_cutoffs = static_cast<int>(cutoffs.size());
+    double const * cutoffs_data = cutoffs.data();
+    int const * need_neigh_data = need_neigh.data();
 
-    nbl_initialize(&neighList);
-
-    return std::unique_ptr<NeighList, PyNeighListDestroy>(std::move(neighList));
-          }, R"pbdoc(
-             Create a new NeighList object.
-
-             Returns:
-                 NeighList: neighList
-             )pbdoc"
-          );
-
-      module.def(
-          "build",
-          [](NeighList * const neighList,
-             py::array_t<double> coords,
-             double const influenceDistance,
-             py::array_t<double> cutoffs,
-             py::array_t<int> need_neigh) {
-            int Natoms_1 = static_cast<int>(coords.size() / 3);
-            int Natoms_2 = static_cast<int>(need_neigh.size());
-
-            if (Natoms_1 != Natoms_2)
-            {
-              throw std::runtime_error(
-                  "\"coords\" size and \"need_neigh\" size do not match!");
-            }
-
-            int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
-
-            double const * c = coords.data();
-            int numberOfCutoffs = static_cast<int>(cutoffs.size());
-            double const * pcutoffs = cutoffs.data();
-            int const * nn = need_neigh.data();
-
-            int error = nbl_build(neighList,
-                                  Natoms,
-                                  c,
-                                  influenceDistance,
-                                  numberOfCutoffs,
-                                  pcutoffs,
-                                  nn);
-            if (error == 1)
-            {
-              throw std::runtime_error(
-                  "Cell size too large! (partilces fly away) or\n"
-                  "Collision of atoms happened!");
-            }
-          },
-          "Build neighList.",
-          py::arg("neighList"),
-          py::arg("coords").noconvert(),
-          py::arg("influenceDistance"),
-          py::arg("cutoffs").noconvert(),
-          py::arg("need_neigh").noconvert());
-
-  module.def("get_neigh",
-             [](NeighList const *const neighList,
-                py::array_t<double> cutoffs,
-                int const neighborListIndex,
-                int const particleNumber) {
-    int numberOfCutoffs = static_cast<int>(cutoffs.size());
-    double const * pcutoffs = cutoffs.data();
-    int numberOfNeighbors = 0;
-    int const * neighOfAtom;
-
-    int error = nbl_get_neigh(neighList,
-                              numberOfCutoffs,
-                              pcutoffs,
-                              neighborListIndex,
-                              particleNumber,
-                              &numberOfNeighbors,
-                              &neighOfAtom);
+    int error = nbl_build(&self,
+                          natoms,
+                          coords_data,
+                          influence_distance,
+                          number_of_cutoffs,
+                          cutoffs_data,
+                          need_neigh_data);
     if (error == 1)
     {
-      throw std::runtime_error(
-          "neighborListIndex >= neighList->numberOfNeighborLists!  or\n"
-          "cutoffs[neighborListIndex] > "
-          "neighList->lists[neighborListIndex]->cutoff!  or\n"
-          "particleNumber >= numberOfParticles!  or\n"
-          "particleNumber < 0!");
+      throw std::runtime_error("Cell size too large! (partilces fly away) or\n"
+                               "Collision of atoms happened!");
+    }
+      }, "Build the neighbor list.",
+         py::arg("coords").noconvert(),
+         py::arg("influence_distance"),
+         py::arg("cutoffs").noconvert(),
+         py::arg("need_neigh").noconvert())
+      .def("get_neigh",
+           [](NeighList &self,
+              py::array_t<double> cutoffs,
+              int const neighbor_list_index,
+              int const particle_number) {
+    int const number_of_cutoffs = static_cast<int>(cutoffs.size());
+    double const * cutoffs_data = cutoffs.data();
+    int number_of_neighbors = 0;
+    int const * neigh_of_atom;
+
+    void const * const data_object
+        = reinterpret_cast<void const * const>(&self);
+
+    int error = nbl_get_neigh(data_object,
+                              number_of_cutoffs,
+                              cutoffs_data,
+                              neighbor_list_index,
+                              particle_number,
+                              &number_of_neighbors,
+                              &neigh_of_atom);
+    if (error == 1)
+    {
+      if (neighbor_list_index >= self.numberOfNeighborLists)
+      {
+        throw std::runtime_error("neighbor_list_index = "
+                                 + std::to_string(neighbor_list_index)
+                                 + " >= self.numberOfNeighborLists = "
+                                 + std::to_string(self.numberOfNeighborLists));
+      }
+      else if (cutoffs_data[neighbor_list_index]
+               > self.lists[neighbor_list_index].cutoff)
+      {
+        throw std::runtime_error(
+            "cutoffs_data[neighbor_list_index] = "
+            + std::to_string(cutoffs_data[neighbor_list_index])
+            + " > self.lists[neighbor_list_index].cutoff = "
+            + std::to_string(self.lists[neighbor_list_index].cutoff));
+      }
+      else
+      {
+        throw std::runtime_error(
+            "particle_number = " + std::to_string(particle_number) + " < 0!");
+      }
     }
 
     // pack as a numpy array
-    auto neighborsOfParticle = py::array(py::buffer_info(
-        const_cast<int *>(neighOfAtom),  // data pointer
+    auto neighbors_of_particle = py::array(py::buffer_info(
+        const_cast<int *>(neigh_of_atom),  // data pointer
         sizeof(int),  // size of one element
         py::format_descriptor<int>::format(),  // Python struct-style
                                                // format descriptor
         1,  // dimension
-        {numberOfNeighbors},  // size of each dimension
+        {number_of_neighbors},  // size of each dimension
         {sizeof(int)}  // stride of each dimension
         ));
 
     py::tuple re(2);
-    re[0] = numberOfNeighbors;
-    re[1] = neighborsOfParticle;
+    re[0] = number_of_neighbors;
+    re[1] = neighbors_of_particle;
     return re;
   }, R"pbdoc(
-     Get the neighList's numberOfNeighbors and neighborsOfParticle.
+     Get the number of neighbors and neighbors of particle.
 
      Returns:
-         int, 1darray: numberOfNeighbors, neighborsOfParticle
+         int, 1darray: number_of_neighbors, neighbors_of_particle
+     )pbdoc",
+     py::arg("cutoffs").noconvert(),
+     py::arg("neighbor_list_index"),
+     py::arg("particle_number"));
+
+  module.def("create", []() {
+    NeighList * neighList = new NeighList;
+    return std::unique_ptr<NeighList, PyNeighListDestroy>(std::move(neighList));
+  }, R"pbdoc(
+     Create a new NeighList object.
+
+     Returns:
+         NeighList: neighList
+     )pbdoc"
+  );
+
+  module.def("initialize", []() {
+    NeighList * neighList = new NeighList;
+    return std::unique_ptr<NeighList, PyNeighListDestroy>(std::move(neighList));
+  }, R"pbdoc(
+     Create a new NeighList object.
+
+     Returns:
+         NeighList: neighList
+     )pbdoc"
+  );
+
+  module.def(
+      "build",
+      [](NeighList * const neighList,
+         py::array_t<double> coords,
+         double const influence_distance,
+         py::array_t<double> cutoffs,
+         py::array_t<int> need_neigh) {
+        int const natoms_1 = static_cast<int>(coords.size() / 3);
+        int const natoms_2 = static_cast<int>(need_neigh.size());
+
+        if (natoms_1 != natoms_2)
+        {
+          MY_WARNING("\"coords\" size and \"need_neigh\" size do not match!");
+        }
+
+        int const natoms = natoms_1 <= natoms_2 ? natoms_1 : natoms_2;
+        double const * coords_data = coords.data();
+        int const number_of_cutoffs = static_cast<int>(cutoffs.size());
+        double const * cutoffs_data = cutoffs.data();
+        int const * need_neigh_data = need_neigh.data();
+
+        int error = nbl_build(neighList,
+                              natoms,
+                              coords_data,
+                              influence_distance,
+                              number_of_cutoffs,
+                              cutoffs_data,
+                              need_neigh_data);
+        if (error == 1)
+        {
+          throw std::runtime_error(
+              "Cell size too large! (partilces fly away) or\n"
+              "Collision of atoms happened!");
+        }
+      },
+      "Build neighList.",
+      py::arg("neighList"),
+      py::arg("coords").noconvert(),
+      py::arg("influence_distance"),
+      py::arg("cutoffs").noconvert(),
+      py::arg("need_neigh").noconvert());
+
+  module.def("get_neigh",
+             [](NeighList const *const neighList,
+                py::array_t<double> cutoffs,
+                int const neighbor_list_index,
+                int const particle_number) {
+    int const number_of_cutoffs = static_cast<int>(cutoffs.size());
+    double const * cutoffs_data = cutoffs.data();
+    int number_of_neighbors = 0;
+    int const * neigh_of_atom;
+
+    int error = nbl_get_neigh(neighList,
+                              number_of_cutoffs,
+                              cutoffs_data,
+                              neighbor_list_index,
+                              particle_number,
+                              &number_of_neighbors,
+                              &neigh_of_atom);
+    if (error == 1)
+    {
+      if (neighbor_list_index >= neighList->numberOfNeighborLists)
+      {
+        throw std::runtime_error(
+            "neighbor_list_index = " + std::to_string(neighbor_list_index)
+            + " >= neighList->numberOfNeighborLists = "
+            + std::to_string(neighList->numberOfNeighborLists));
+      }
+      else if (cutoffs_data[neighbor_list_index]
+               > neighList->lists[neighbor_list_index].cutoff)
+      {
+        throw std::runtime_error(
+            "cutoffs_data[neighbor_list_index] = "
+            + std::to_string(cutoffs_data[neighbor_list_index])
+            + " > neighList->lists[neighbor_list_index].cutoff = "
+            + std::to_string(neighList->lists[neighbor_list_index].cutoff));
+      }
+      else
+      {
+        throw std::runtime_error(
+            "particle_number = " + std::to_string(particle_number) + " < 0!");
+      }
+    }
+
+    // pack as a numpy array
+    auto neighbors_of_particle = py::array(py::buffer_info(
+        const_cast<int *>(neigh_of_atom),  // data pointer
+        sizeof(int),  // size of one element
+        py::format_descriptor<int>::format(),  // Python struct-style
+                                               // format descriptor
+        1,  // dimension
+        {number_of_neighbors},  // size of each dimension
+        {sizeof(int)}  // stride of each dimension
+        ));
+
+    py::tuple re(2);
+    re[0] = number_of_neighbors;
+    re[1] = neighbors_of_particle;
+    return re;
+  }, R"pbdoc(
+     Get the neighList's number of neighbors and neighbors of particle.
+
+     Returns:
+         int, 1darray: number_of_neighbors, neighbors_of_particle
      )pbdoc",
      py::arg("neighList"),
      py::arg("cutoffs").noconvert(),
-     py::arg("neighborListIndex"),
-     py::arg("particleNumber"));
+     py::arg("neighbor_list_index"),
+     py::arg("particle_number"));
 
   // cannot bind `nbl_get_neigh_kim` directly, since it has pointer arguments
   // so we return a pointer to this function
@@ -169,39 +285,37 @@ PYBIND11_MODULE(neighlist, module)
   });
 
   module.def("create_paddings",
-             [](double const influenceDistance,
+             [](double const influence_distance,
                 py::array_t<double> cell,
-                py::array_t<int> PBC,
+                py::array_t<int> pbc,
                 py::array_t<double> coords,
                 py::array_t<int> species) {
-    int Natoms_1 = static_cast<int>(coords.size() / 3);
-    int Natoms_2 = static_cast<int>(species.size());
+    int const natoms_1 = static_cast<int>(coords.size() / 3);
+    int const natoms_2 = static_cast<int>(species.size());
 
-    if (Natoms_1 != Natoms_2)
+    if (natoms_1 != natoms_2)
     {
-      throw std::runtime_error(
-          "\"coords\" size and \"species\" size do not match!");
+      MY_WARNING("\"coords\" size and \"need_neigh\" size do not match!");
     }
 
-    int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
+    int const natoms = natoms_1 <= natoms_2 ? natoms_1 : natoms_2;
+    double const * cell_data = cell.data();
+    int const * pbc_data = pbc.data();
+    double const * coords_data = coords.data();
+    int const * species_data = species.data();
 
-    double const * cell2 = cell.data();
-    int const * PBC2 = PBC.data();
-    double const * coords2 = coords.data();
-    int const * species2 = species.data();
-
-    int Npad;
+    int number_of_pads;
     std::vector<double> pad_coords;
     std::vector<int> pad_species;
     std::vector<int> pad_image;
 
-    int error = nbl_create_paddings(Natoms,
-                                    influenceDistance,
-                                    cell2,
-                                    PBC2,
-                                    coords2,
-                                    species2,
-                                    Npad,
+    int error = nbl_create_paddings(natoms,
+                                    influence_distance,
+                                    cell_data,
+                                    pbc_data,
+                                    coords_data,
+                                    species_data,
+                                    number_of_pads,
                                     pad_coords,
                                     pad_species,
                                     pad_image);
@@ -217,7 +331,7 @@ PYBIND11_MODULE(neighlist, module)
                                     sizeof(double),
                                     py::format_descriptor<double>::format(),
                                     2,
-                                    {Npad, 3},
+                                    {number_of_pads, 3},
                                     {sizeof(double) * 3, sizeof(double)}));
 
     // pack as a numpy array
@@ -226,7 +340,7 @@ PYBIND11_MODULE(neighlist, module)
                                     sizeof(int),
                                     py::format_descriptor<int>::format(),
                                     1,
-                                    {Npad},
+                                    {number_of_pads},
                                     {sizeof(int)}));
 
     // pack as a numpy array
@@ -235,7 +349,7 @@ PYBIND11_MODULE(neighlist, module)
                                     sizeof(int),
                                     py::format_descriptor<int>::format(),
                                     1,
-                                    {Npad},
+                                    {number_of_pads},
                                     {sizeof(int)}));
 
     py::tuple re(3);
@@ -250,9 +364,9 @@ PYBIND11_MODULE(neighlist, module)
          2darray, 1darray, 1darray: coordinates_of_paddings,
              species_code_of_paddings, master_particle_of_paddings
      )pbdoc",
-     py::arg("influenceDistance"),
+     py::arg("influence_distance"),
      py::arg("cell").noconvert(),
-     py::arg("PBC").noconvert(),
+     py::arg("pbc").noconvert(),
      py::arg("coords").noconvert(),
      py::arg("species").noconvert());
 }

--- a/kimpy/neighlist/neighbor_list_bind.cpp
+++ b/kimpy/neighlist/neighbor_list_bind.cpp
@@ -8,116 +8,134 @@
 #include <memory>
 #include <vector>
 
-#define MY_ERROR(message)                                             \
-  {                                                                   \
-    std::cerr << "* Error (Neighbor List): \"" << message             \
-              << "\" : " << __LINE__ << ":" << __FILE__ << std::endl; \
-    std::exit(1);                                                     \
-  }
-
-#define MY_WARNING(message)                                           \
-  {                                                                   \
-    std::cerr << "* Error (Neighbor List) : \"" << message            \
-              << "\" : " << __LINE__ << ":" << __FILE__ << std::endl; \
-  }
-
-
 namespace py = pybind11;
+
+
+namespace {
+struct PyNeighListDestroy {
+  void operator()(NeighList *neighList) const {
+    nbl_clean(&neighList);
+  }
+};
+} // namespace
 
 
 PYBIND11_MODULE(neighlist, module)
 {
   module.doc() = "Python binding to neighbor list.";
 
-  // py::nodelete, not to destroy object by python garbage collection
-  py::class_<NeighList, std::unique_ptr<NeighList, py::nodelete> >(
-      module, "NeighList", py::module_local())
-      .def(py::init());
+  py::class_<NeighList, std::unique_ptr<NeighList, PyNeighListDestroy>>(
+    module, "NeighList", py::module_local()).def(py::init());
+
+  module.def("create", []() {
+      NeighList *neighList;
+
+      nbl_initialize(&neighList);
+
+      return std::unique_ptr<NeighList, PyNeighListDestroy>(
+        std::move(neighList));
+    }, "Create a new NeighList object.",
+       "Return neighList");
 
   module.def("initialize", []() {
-    NeighList * nl;
-    nbl_initialize(&nl);
-    return nl;
-  });
+      NeighList *neighList;
 
-  module.def("clean", [](NeighList * nl) { nbl_clean(&nl); });
+      nbl_initialize(&neighList);
 
-  module.def(
-      "build",
-      [](NeighList * const nl,
-         py::array_t<double> coords,
-         double const influenceDistance,
-         py::array_t<double> cutoffs,
-         py::array_t<int> need_neigh) {
-        int Natoms_1 = static_cast<int>(coords.size() / 3);
-        int Natoms_2 = static_cast<int>(need_neigh.size());
-        
-        int error = Natoms_1 == Natoms_2 ? 0 : 1;
-        if (error)
-          MY_WARNING("\"coords\" size and \"need_neigh\" size do not match.");
+      return std::unique_ptr<NeighList, PyNeighListDestroy>(
+        std::move(neighList));
+    }, "Create a new NeighList object.",
+       "Return neighList");
 
-        int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
-        double const * c = coords.data();
-        int numberOfCutoffs = static_cast<int>(cutoffs.size());
-        double const * pcutoffs = cutoffs.data();
-        int const * nn = need_neigh.data();
-        
-        error = error || nbl_build(nl,
-                                   Natoms,
-                                   c,
-                                   influenceDistance,
-                                   numberOfCutoffs,
-                                   pcutoffs,
-                                   nn);
-        return error;
-      },
-      py::arg("NeighList"),
-      py::arg("coords").noconvert(),
-      py::arg("influenceDistance"),
-      py::arg("cutoffs").noconvert(),
-      py::arg("need_neigh").noconvert());
+  module.def("build",
+             [](NeighList *const neighList,
+                py::array_t<double> coords,
+                double const influenceDistance,
+                py::array_t<double> cutoffs,
+                py::array_t<int> need_neigh) {
+    int Natoms_1 = static_cast<int>(coords.size() / 3);
+    int Natoms_2 = static_cast<int>(need_neigh.size());
 
+    if (Natoms_1 != Natoms_2) {
+      throw std::runtime_error(
+        "\"coords\" size and \"need_neigh\" size do not match!");
+    }
 
-  module.def(
-      "get_neigh",
-      [](NeighList const * const nl,
-         py::array_t<double> cutoffs,
-         int const neighborListIndex,
-         int const particleNumber) {
-        int numberOfCutoffs = static_cast<int>(cutoffs.size());
-        double const * pcutoffs = cutoffs.data();
-        int numberOfNeighbors = 0;
-        int const * neighOfAtom;
-        int error = nbl_get_neigh(nl,
-                                  numberOfCutoffs,
-                                  pcutoffs,
-                                  neighborListIndex,
-                                  particleNumber,
-                                  &numberOfNeighbors,
-                                  &neighOfAtom);
+    int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
 
-        // pack as a numpy array
-        auto neighborsOfParticle = py::array(py::buffer_info(
-            const_cast<int *>(neighOfAtom),        // data pointer
-            sizeof(int),                           // size of one element
-            py::format_descriptor<int>::format(),  // Python struct-style
-                                                   // format descriptor
-            1,                                     // dimension
-            {numberOfNeighbors},                   // size of each dimension
-            {sizeof(int)}                          // stride of each dimension
-            ));
+    double const *c = coords.data();
+    int numberOfCutoffs = static_cast<int>(cutoffs.size());
+    double const *pcutoffs = cutoffs.data();
+    int const *nn = need_neigh.data();
 
-        py::tuple re(3);
-        re[0] = numberOfNeighbors;
-        re[1] = neighborsOfParticle;
-        re[2] = error;
-        return re;
-      },
-      py::arg("NeighList"),
-      py::arg("cutoffs").noconvert(),
-      py::arg("neighborListIndex"),
-      py::arg("particle_number"),
-      "Return(number_of_neighbors, neighbors_of_particle, error)");
+    int error = nbl_build(neighList,
+                          Natoms,
+                          c,
+                          influenceDistance,
+                          numberOfCutoffs,
+                          pcutoffs,
+                          nn);
+    if (error == 1) {
+      throw std::runtime_error(
+        "Cell size too large! (partilces fly away) or\n"
+        "Collision of atoms happened!");
+    }
+  }, "Build neighList.",
+     py::arg("neighList"),
+     py::arg("coords").noconvert(),
+     py::arg("influenceDistance"),
+     py::arg("cutoffs").noconvert(),
+     py::arg("need_neigh").noconvert());
+
+  module.def("get_neigh",
+             [](NeighList const *const neighList,
+                py::array_t<double> cutoffs,
+                int const neighborListIndex,
+                int const particleNumber) {
+    int numberOfCutoffs = static_cast<int>(cutoffs.size());
+    double const *pcutoffs = cutoffs.data();
+    int numberOfNeighbors = 0;
+    int const *neighOfAtom;
+
+    int error = nbl_get_neigh(neighList,
+                              numberOfCutoffs,
+                              pcutoffs,
+                              neighborListIndex,
+                              particleNumber,
+                              &numberOfNeighbors,
+                              &neighOfAtom);
+    if (error == 1) {
+      throw std::runtime_error(
+        "neighborListIndex >= neighList->numberOfNeighborLists!  or\n"
+        "cutoffs[neighborListIndex] > "
+        "neighList->lists[neighborListIndex]->cutoff!  or\n"
+        "particleNumber >= numberOfParticles!  or\n"
+        "particleNumber < 0!");
+    }
+
+    // pack as a numpy array
+    auto neighborsOfParticle =
+      py::array(
+        py::buffer_info(
+          const_cast<int *>(neighOfAtom),        // data pointer
+          sizeof(int),                           // size of one element
+          py::format_descriptor<int>::format(),  // Python struct-style
+                                                 // format descriptor
+          1,                                     // dimension
+          {numberOfNeighbors},                   // size of each dimension
+          {sizeof(int)}                          // stride of each dimension
+      ));
+
+    py::tuple re(2);
+    re[0] = numberOfNeighbors;
+    re[1] = neighborsOfParticle;
+    return re;
+  }, "Get the neighList's numberOfNeighbors and neighborsOfParticle.",
+     py::arg("neighList"),
+     py::arg("cutoffs").noconvert(),
+     py::arg("neighborListIndex"),
+     py::arg("particleNumber"),
+     "Return(numberOfNeighbors, neighborsOfParticle)");
 
   // cannot bind `nbl_get_neigh_kim` directly, since it has pointer arguments
   // so we return a pointer to this function
@@ -128,81 +146,85 @@ PYBIND11_MODULE(neighlist, module)
     return (void const *) &nbl_get_neigh;
   });
 
+  module.def("create_paddings",
+             [](double const influenceDistance,
+                py::array_t<double> cell,
+                py::array_t<int> PBC,
+                py::array_t<double> coords,
+                py::array_t<int> species) {
+    int Natoms_1 = static_cast<int>(coords.size() / 3);
+    int Natoms_2 = static_cast<int>(species.size());
 
-  module.def(
-      "create_paddings",
-      [](double const influenceDistance,
-         py::array_t<double> cell,
-         py::array_t<int> PBC,
-         py::array_t<double> coords,
-         py::array_t<int> species) {
-        int Natoms_1 = static_cast<int>(coords.size() / 3);
-        int Natoms_2 = static_cast<int>(species.size());
-        int error = Natoms_1 == Natoms_2 ? 0 : 1;
-        int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
-        if (error)
-          MY_WARNING("\"coords\" size and \"species\" size do not match.");
+    if (Natoms_1 != Natoms_2) {
+      throw std::runtime_error(
+          "\"coords\" size and \"species\" size do not match!");
+    }
 
-        double const * cell2 = cell.data();
-        int const * PBC2 = PBC.data();
-        double const * coords2 = coords.data();
-        int const * species2 = species.data();
+    int Natoms = Natoms_1 <= Natoms_2 ? Natoms_1 : Natoms_2;
 
-        int Npad;
-        std::vector<double> pad_coords;
-        std::vector<int> pad_species;
-        std::vector<int> pad_image;
+    double const *cell2 = cell.data();
+    int const *PBC2 = PBC.data();
+    double const *coords2 = coords.data();
+    int const *species2 = species.data();
 
-        error = error || nbl_create_paddings(Natoms,
-                                             influenceDistance,
-                                             cell2,
-                                             PBC2,
-                                             coords2,
-                                             species2,
-                                             Npad,
-                                             pad_coords,
-                                             pad_species,
-                                             pad_image);
+    int Npad;
+    std::vector<double> pad_coords;
+    std::vector<int> pad_species;
+    std::vector<int> pad_image;
 
-        // pack as a 2D numpy array
-        auto pad_coords_array
-          = py::array(py::buffer_info(pad_coords.data(),
-                                      sizeof(double),
-                                      py::format_descriptor<double>::format(),
-                                      2,
-                                      {Npad, 3},
-                                      {sizeof(double) * 3, sizeof(double)}));
+    int error = nbl_create_paddings(Natoms,
+                                    influenceDistance,
+                                    cell2,
+                                    PBC2,
+                                    coords2,
+                                    species2,
+                                    Npad,
+                                    pad_coords,
+                                    pad_species,
+                                    pad_image);
+    if (error == 1) {
+      throw std::runtime_error(
+          "In inverting the cell matrix, the determinant is 0!");
+    }
 
-        // pack as a numpy array
-        auto pad_species_array
-          = py::array(py::buffer_info(pad_species.data(),
-                                      sizeof(int),
-                                      py::format_descriptor<int>::format(),
-                                      1,
-                                      {Npad},
-                                      {sizeof(int)}));
+    // pack as a 2D numpy array
+    auto coordinates_of_paddings =
+      py::array(py::buffer_info(pad_coords.data(),
+                                sizeof(double),
+                                py::format_descriptor<double>::format(),
+                                2,
+                                {Npad, 3},
+                                {sizeof(double) *3, sizeof(double)}));
 
-        // pack as a numpy array
-        auto pad_image_array
-          = py::array(py::buffer_info(pad_image.data(),
-                                      sizeof(int),
-                                      py::format_descriptor<int>::format(),
-                                      1,
-                                      {Npad},
-                                      {sizeof(int)}));
+    // pack as a numpy array
+    auto species_code_of_paddings =
+      py::array(py::buffer_info(pad_species.data(),
+                                sizeof(int),
+                                py::format_descriptor<int>::format(),
+                                1,
+                                {Npad},
+                                {sizeof(int)}));
 
-        py::tuple re(4);
-        re[0] = pad_coords_array;
-        re[1] = pad_species_array;
-        re[2] = pad_image_array;
-        re[3] = error;
-        return re;
-      },
-      py::arg("influenceDistance"),
-      py::arg("cell").noconvert(),
-      py::arg("PBC").noconvert(),
-      py::arg("coordinates").noconvert(),
-      py::arg("species_code").noconvert(),
-      "Return(coordinates_of_paddings, species_code_of_paddings, \
-        master_particle_of_paddings, error)");
+    // pack as a numpy array
+    auto master_particle_of_paddings =
+      py::array(py::buffer_info(pad_image.data(),
+                                sizeof(int),
+                                py::format_descriptor<int>::format(),
+                                1,
+                                {Npad},
+                                {sizeof(int)}));
+
+    py::tuple re(3);
+    re[0] = coordinates_of_paddings;
+    re[1] = species_code_of_paddings;
+    re[2] = master_particle_of_paddings;
+    return re;
+  }, "Create padding.",
+     py::arg("influenceDistance"),
+     py::arg("cell").noconvert(),
+     py::arg("PBC").noconvert(),
+     py::arg("coords").noconvert(),
+     py::arg("species").noconvert(),
+     "Return(coordinates_of_paddings, species_code_of_paddings, "
+     "master_particle_of_paddings)");
 }

--- a/kimpy/py_kim_wrapper.h
+++ b/kimpy/py_kim_wrapper.h
@@ -3,8 +3,8 @@
 
 #include <memory>
 
-#include "KIM_Model.hpp"
 #include "KIM_ComputeArguments.hpp"
+#include "KIM_Model.hpp"
 #include "sim_buffer.h"
 
 /**
@@ -29,29 +29,27 @@
 
 class PyModel : public std::enable_shared_from_this<PyModel>
 {
-  public:
-  KIM::Model *_model{nullptr};
+ public:
+  KIM::Model * _model {nullptr};
 
   PyModel() = default;
-  ~PyModel() {
-    if (_model) {
-      KIM::Model::Destroy(&_model);
-    }
+  ~PyModel()
+  {
+    if (_model) { KIM::Model::Destroy(&_model); }
   }
 };
 
 
-class PyComputeArguments : public
-  std::enable_shared_from_this<PyComputeArguments>
+class PyComputeArguments :
+    public std::enable_shared_from_this<PyComputeArguments>
 {
-  public:
-  KIM::ComputeArguments *_compute_arguments{nullptr};
+ public:
+  KIM::ComputeArguments * _compute_arguments {nullptr};
 
-  std::shared_ptr<PyModel> _py_model{nullptr};
+  std::shared_ptr<PyModel> _py_model {nullptr};
 
   PyComputeArguments() = default;
-  PyComputeArguments(
-    std::shared_ptr<PyModel> py_model) : _py_model(py_model) {}
+  PyComputeArguments(std::shared_ptr<PyModel> py_model) : _py_model(py_model) {}
 
   ~PyComputeArguments()
   {
@@ -59,7 +57,7 @@ class PyComputeArguments : public
     {
       if (_compute_arguments)
       {
-        SimBuffer *sim_buffer;
+        SimBuffer * sim_buffer;
 
         _compute_arguments->GetSimulatorBufferPointer((void **) &sim_buffer);
 
@@ -85,4 +83,4 @@ class PyComputeArguments : public
   }
 };
 
-#endif // PY_KIM_WRAPPER_H_
+#endif  // PY_KIM_WRAPPER_H_

--- a/kimpy/py_kim_wrapper.h
+++ b/kimpy/py_kim_wrapper.h
@@ -22,7 +22,7 @@
  * lead to memory leaks/use-after-free (segmentation fault) errors.
  *
  * By using the current wrapper class we remove the need for user requirement
- * to explicitely edetrsoy the object. Also provide a information that allows
+ * to explicitly destroy the object. Also provide information that allows
  * the Python garbage collection to take care of the objects memory management.
  */
 

--- a/kimpy/py_kim_wrapper.h
+++ b/kimpy/py_kim_wrapper.h
@@ -1,0 +1,88 @@
+#ifndef PY_KIM_WRAPPER_H_
+#define PY_KIM_WRAPPER_H_
+
+#include <memory>
+
+#include "KIM_Model.hpp"
+#include "KIM_ComputeArguments.hpp"
+#include "sim_buffer.h"
+
+/**
+ * @brief A convenient wrapper over the \c Model and \c ComputeArguments
+ * classes.
+ *
+ * \c Model class provides the primary interface to a %KIM API Model object
+ * and is meant to be used by simulators. The incomplete class is not exposed
+ * to the user and it is hidden behind a forwarding facade. This class has a
+ * private constructor & destructor. It is also creating a new
+ * \c ComputeArguments object for the Model object.
+ *
+ * The naive bindings via pybind11 and using ``py::nodelete`` class requires
+ * users to manullay create and destroy the objects. Which could very easily
+ * lead to memory leaks/use-after-free (segmentation fault) errors.
+ *
+ * By using the current wrapper class we remove the need for user requirement
+ * to explicitely edetrsoy the object. Also provide a information that allows
+ * the Python garbage collection to take care of the objects memory management.
+ */
+
+
+class PyModel : public std::enable_shared_from_this<PyModel>
+{
+  public:
+  KIM::Model *_model{nullptr};
+
+  PyModel() = default;
+  ~PyModel() {
+    if (_model) {
+      KIM::Model::Destroy(&_model);
+    }
+  }
+};
+
+
+class PyComputeArguments : public
+  std::enable_shared_from_this<PyComputeArguments>
+{
+  public:
+  KIM::ComputeArguments *_compute_arguments{nullptr};
+
+  std::shared_ptr<PyModel> _py_model{nullptr};
+
+  PyComputeArguments() = default;
+  PyComputeArguments(
+    std::shared_ptr<PyModel> py_model) : _py_model(py_model) {}
+
+  ~PyComputeArguments()
+  {
+    if (_py_model)
+    {
+      if (_compute_arguments)
+      {
+        SimBuffer *sim_buffer;
+
+        _compute_arguments->GetSimulatorBufferPointer((void **) &sim_buffer);
+
+        if (sim_buffer)
+        {
+          for (std::size_t i = 0; i < sim_buffer->callbacks.size(); ++i)
+          {
+            if (sim_buffer->callbacks[i])
+            {
+              delete sim_buffer->callbacks[i];
+              sim_buffer->callbacks[i] = nullptr;
+            }
+          }
+
+          delete sim_buffer;
+          sim_buffer = nullptr;
+        }
+
+        auto model = _py_model->_model;
+        model->ComputeArgumentsDestroy(&_compute_arguments);
+      }
+    }
+  }
+};
+
+#endif // PY_KIM_WRAPPER_H_

--- a/kimpy/sim_buffer.h
+++ b/kimpy/sim_buffer.h
@@ -7,8 +7,10 @@
 
 namespace py = pybind11;
 
-struct SimBuffer {
+
+struct SimBuffer
+{
   std::vector<py::dict *> callbacks;
 };
 
-#endif  // SIM_BUFFER_
+#endif // SIM_BUFFER_

--- a/kimpy/sim_buffer.h
+++ b/kimpy/sim_buffer.h
@@ -13,4 +13,4 @@ struct SimBuffer
   std::vector<py::dict *> callbacks;
 };
 
-#endif // SIM_BUFFER_
+#endif  // SIM_BUFFER_

--- a/scripts/KIM_FieldName_bind.cpp-template
+++ b/scripts/KIM_FieldName_bind.cpp-template
@@ -22,21 +22,7 @@ PYBIND11_MODULE(field_name, module)
       .def("known", &FieldName::Known)
       .def(py::self == py::self)
       .def(py::self != py::self)
-      .def("__repr__", &FieldName::ToString)
-      .def(py::pickle(
-          // __getstate__
-          [](FieldName const & fieldName) {
-            // Return a tuple that fully encodes
-            // the state of the fieldName object
-            return py::make_tuple(fieldName.fieldNameID);
-          },
-          // __setstate__
-          [](py::tuple t) {
-            if (t.size() != 1) { throw std::runtime_error("Invalid state!"); }
-            // Create a new instance
-            FieldName fieldName(t[0].cast<int>());
-            return fieldName;
-          }));
+      .def("__repr__", &FieldName::ToString);
 
   // functions
 

--- a/scripts/KIM_FieldName_bind.cpp-template
+++ b/scripts/KIM_FieldName_bind.cpp-template
@@ -1,5 +1,5 @@
-#include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
 
 #include <string>
 
@@ -8,7 +8,8 @@
 namespace py = pybind11;
 using namespace KIM;
 
-PYBIND11_MODULE(field_name, module) {
+PYBIND11_MODULE(field_name, module)
+{
   module.doc() = "Python binding to KIM_FieldName.hpp";
 
   // classes
@@ -16,43 +17,39 @@ PYBIND11_MODULE(field_name, module) {
   py::class_<FieldName> cl(module, "FieldName");
 
   cl.def(py::init<>())
-    .def(py::init<int const>())
-    .def(py::init<std::string const>())
-    .def("known", &FieldName::Known)
-    .def(py::self == py::self)
-    .def(py::self != py::self)
-    .def("__repr__", &FieldName::ToString)
-    .def(py::pickle(
-      // __getstate__
-      [](FieldName const &fieldName) {
-        // Return a tuple that fully encodes
-        // the state of the fieldName object
-        return py::make_tuple(fieldName.fieldNameID);
-      },
-      // __setstate__
-      [](py::tuple t) {
-        if (t.size() != 1) {
-          throw std::runtime_error("Invalid state!");
-        }
-        // Create a new instance
-        FieldName fieldName(t[0].cast<int>());
-        return fieldName;
-      }
-    ));
+      .def(py::init<int const>())
+      .def(py::init<std::string const>())
+      .def("known", &FieldName::Known)
+      .def(py::self == py::self)
+      .def(py::self != py::self)
+      .def("__repr__", &FieldName::ToString)
+      .def(py::pickle(
+          // __getstate__
+          [](FieldName const & fieldName) {
+            // Return a tuple that fully encodes
+            // the state of the fieldName object
+            return py::make_tuple(fieldName.fieldNameID);
+          },
+          // __setstate__
+          [](py::tuple t) {
+            if (t.size() != 1) { throw std::runtime_error("Invalid state!"); }
+            // Create a new instance
+            FieldName fieldName(t[0].cast<int>());
+            return fieldName;
+          }));
 
   // functions
 
   module.def("get_field_name", [](int const index) {
-      FieldName fieldName;
+    FieldName fieldName;
 
-      int error = FIELD_NAME::GetFieldName(
-        index, &fieldName);
-      if (error == 1) {
-        throw std::runtime_error(
-          "index < 0 or index >= numberOfFieldNames!");
-      }
+    int error = FIELD_NAME::GetFieldName(index, &fieldName);
+    if (error == 1)
+    {
+      throw std::runtime_error("index < 0 or index >= numberOfFieldNames!");
+    }
 
-      return fieldName;
+    return fieldName;
     }, R"pbdoc(
        Get the identity of each defined standard FieldName.
 
@@ -62,20 +59,20 @@ PYBIND11_MODULE(field_name, module) {
        py::arg("index"));
 
   module.def("get_number_of_field_names", []() {
-      int numberOfFieldNames;
+    int numberOfFieldNames;
 
-      FIELD_NAME::GetNumberOfFieldNames(
-        &numberOfFieldNames);
+    FIELD_NAME::GetNumberOfFieldNames(&numberOfFieldNames);
 
-      return numberOfFieldNames;
+    return numberOfFieldNames;
     }, R"pbdoc(
        Get the number of standard FieldName.
 
        Returns:
            int: numberOfFieldNames
-       )pbdoc");
+       )pbdoc"
+    );
 
   // attributes
 
-rpls_attributes
+  rpls_attributes
 }

--- a/scripts/KIM_FieldName_bind.cpp-template
+++ b/scripts/KIM_FieldName_bind.cpp-template
@@ -27,38 +27,38 @@ PYBIND11_MODULE(field_name, module)
   // functions
 
   module.def("get_field_name", [](int const index) {
-    FieldName fieldName;
+    FieldName field_name;
 
-    int error = FIELD_NAME::GetFieldName(index, &fieldName);
+    int error = FIELD_NAME::GetFieldName(index, &field_name);
     if (error == 1)
     {
       throw std::runtime_error("index < 0 or index >= numberOfFieldNames!");
     }
 
-    return fieldName;
+    return field_name;
     }, R"pbdoc(
        Get the identity of each defined standard FieldName.
 
        Returns:
-           FieldName: fieldName
+           FieldName: field_name
        )pbdoc",
        py::arg("index"));
 
   module.def("get_number_of_field_names", []() {
-    int numberOfFieldNames;
+    int number_of_field_names;
 
-    FIELD_NAME::GetNumberOfFieldNames(&numberOfFieldNames);
+    FIELD_NAME::GetNumberOfFieldNames(&number_of_field_names);
 
-    return numberOfFieldNames;
+    return number_of_field_names;
     }, R"pbdoc(
        Get the number of standard FieldName.
 
        Returns:
-           int: numberOfFieldNames
+           int: number_of_field_names
        )pbdoc"
     );
 
   // attributes
 
-  rpls_attributes
+rpls_attributes
 }

--- a/scripts/KIM_FieldName_bind.cpp-template
+++ b/scripts/KIM_FieldName_bind.cpp-template
@@ -8,52 +8,68 @@
 namespace py = pybind11;
 using namespace KIM;
 
-
 PYBIND11_MODULE(field_name, module) {
   module.doc() = "Python binding to KIM_FieldName.hpp";
 
   // classes
 
   py::class_<FieldName> cl(module, "FieldName");
-  
+
   cl.def(py::init<>())
     .def(py::init<int const>())
     .def(py::init<std::string const>())
     .def("known", &FieldName::Known)
     .def(py::self == py::self)
     .def(py::self != py::self)
-    .def("__repr__", &FieldName::ToString);
-
+    .def("__repr__", &FieldName::ToString)
+    .def(py::pickle(
+      // __getstate__
+      [](FieldName const &fieldName) {
+        // Return a tuple that fully encodes
+        // the state of the fieldName object
+        return py::make_tuple(fieldName.fieldNameID);
+      },
+      // __setstate__
+      [](py::tuple t) {
+        if (t.size() != 1) {
+          throw std::runtime_error("Invalid state!");
+        }
+        // Create a new instance
+        FieldName fieldName(t[0].cast<int>());
+        return fieldName;
+      }
+    ));
 
   // functions
 
-  module.def("get_field_name",
-    [](int const index) {
+  module.def("get_field_name", [](int const index) {
       FieldName fieldName;
-      int error = FIELD_NAME::GetFieldName(index, &fieldName);
 
-      py::tuple re(2);
-      re[0] = fieldName;
-      re[1] = error;
-      return re;
-    },
-    py::arg("index"),
-    "Return(FieldName, error)"
+      int error = FIELD_NAME::GetFieldName(
+        index, &fieldName);
+      if (error == 1) {
+        throw std::runtime_error(
+          "index < 0 or index >= numberOfFieldNames!");
+      }
+
+      return fieldName;
+    }, "Get the identity of each defined standard FieldName.",
+       py::arg("index"),
+       "Return fieldName"
   );
 
-  module.def("get_number_of_field_names",
-    []() {
+  module.def("get_number_of_field_names", []() {
       int numberOfFieldNames;
-      FIELD_NAME::GetNumberOfFieldNames(&numberOfFieldNames);
-      return numberOfFieldNames;
-    },
-    "Return numberOfFieldNames"
-  );
 
+      FIELD_NAME::GetNumberOfFieldNames(
+        &numberOfFieldNames);
+
+      return numberOfFieldNames;
+    }, "Get the number of standard FieldName.",
+       "Return numberOfFieldNames"
+  );
 
   // attributes
 
 rpls_attributes
-
 }
-

--- a/scripts/KIM_FieldName_bind.cpp-template
+++ b/scripts/KIM_FieldName_bind.cpp-template
@@ -53,10 +53,13 @@ PYBIND11_MODULE(field_name, module) {
       }
 
       return fieldName;
-    }, "Get the identity of each defined standard FieldName.",
-       py::arg("index"),
-       "Return fieldName"
-  );
+    }, R"pbdoc(
+       Get the identity of each defined standard FieldName.
+
+       Returns:
+           FieldName: fieldName
+       )pbdoc",
+       py::arg("index"));
 
   module.def("get_number_of_field_names", []() {
       int numberOfFieldNames;
@@ -65,9 +68,12 @@ PYBIND11_MODULE(field_name, module) {
         &numberOfFieldNames);
 
       return numberOfFieldNames;
-    }, "Get the number of standard FieldName.",
-       "Return numberOfFieldNames"
-  );
+    }, R"pbdoc(
+       Get the number of standard FieldName.
+
+       Returns:
+           int: numberOfFieldNames
+       )pbdoc");
 
   // attributes
 

--- a/scripts/generate_CollectionItemType_bind_test.py
+++ b/scripts/generate_CollectionItemType_bind_test.py
@@ -9,11 +9,7 @@ fields = {
 }
 
 
-attributes = [
-    'modelDriver',
-    'portableModel',
-    'simulatorModel'
-]
+attributes = ['modelDriver', 'portableModel', 'simulatorModel']
 
 generate_bind(fields, attributes)
 generate_test(fields, attributes)

--- a/scripts/generate_Collection_bind_test.py
+++ b/scripts/generate_Collection_bind_test.py
@@ -8,12 +8,7 @@ fields = {
     'field_name': 'collection',
 }
 
-attributes = [
-    'system',
-    'user',
-    'environmentVariable',
-    'currentWorkingDirectory'
-]
+attributes = ['system', 'user', 'environmentVariable', 'currentWorkingDirectory']
 
 generate_bind(fields, attributes)
 generate_test(fields, attributes)

--- a/scripts/generate_ComputeCallbackName_bind_test.py
+++ b/scripts/generate_ComputeCallbackName_bind_test.py
@@ -7,11 +7,7 @@ fields = {
     'field_name': 'compute_callback_name',
 }
 
-attributes = [
-    'GetNeighborList',
-    'ProcessDEDrTerm',
-    'ProcessD2EDr2Term'
-]
+attributes = ['GetNeighborList', 'ProcessDEDrTerm', 'ProcessD2EDr2Term']
 
 generate_bind(fields, attributes)
 generate_test(fields, attributes)

--- a/scripts/generate_DataType_bind_test.py
+++ b/scripts/generate_DataType_bind_test.py
@@ -7,10 +7,7 @@ fields = {
     'field_name': 'data_type',
 }
 
-attributes = [
-    'Integer',
-    'Double'
-]
+attributes = ['Integer', 'Double']
 
 generate_bind(fields, attributes)
 generate_test(fields, attributes)

--- a/scripts/generate_LanguageName_bind_test.py
+++ b/scripts/generate_LanguageName_bind_test.py
@@ -7,11 +7,7 @@ fields = {
     'field_name': 'language_name',
 }
 
-attributes = [
-    'cpp',
-    'c',
-    'fortran'
-]
+attributes = ['cpp', 'c', 'fortran']
 
 generate_bind(fields, attributes)
 generate_test(fields, attributes)

--- a/scripts/generate_LogVerbosity_bind_test.py
+++ b/scripts/generate_LogVerbosity_bind_test.py
@@ -11,14 +11,7 @@ fields['FieldName'] = 'LogVerbosity'
 fields['fieldName'] = 'logVerbosity'
 fields['field_name'] = 'log_verbosity'
 
-attributes = [
-    'silent',
-    'fatal',
-    'error',
-    'warning',
-    'information',
-    'debug'
-]
+attributes = ['silent', 'fatal', 'error', 'warning', 'information', 'debug']
 
 generate_bind(fields, attributes)
 generate_test(fields, attributes)

--- a/scripts/generate_Numbering_bind_test.py
+++ b/scripts/generate_Numbering_bind_test.py
@@ -7,10 +7,7 @@ fields = {
     'field_name': 'numbering',
 }
 
-attributes = [
-    'zeroBased',
-    'oneBased'
-]
+attributes = ['zeroBased', 'oneBased']
 
 generate_bind(fields, attributes)
 generate_test(fields, attributes)

--- a/scripts/generate_SupportStatus_bind_test.py
+++ b/scripts/generate_SupportStatus_bind_test.py
@@ -11,12 +11,7 @@ fields['FieldName'] = 'SupportStatus'
 fields['fieldName'] = 'supportStatus'
 fields['field_name'] = 'support_status'
 
-attributes = [
-    'requiredByAPI',
-    'notSupported',
-    'required',
-    'optional'
-]
+attributes = ['requiredByAPI', 'notSupported', 'required', 'optional']
 
 generate_bind(fields, attributes)
 generate_test(fields, attributes)

--- a/scripts/generate_UnitSystem_bind_test.py
+++ b/scripts/generate_UnitSystem_bind_test.py
@@ -7,14 +7,7 @@ length_unit = {
     'field_name': 'length_unit',
 }
 
-length_attributes = [
-    'unused',
-    'A',
-    'Bohr',
-    'cm',
-    'm',
-    'nm'
-]
+length_attributes = ['unused', 'A', 'Bohr', 'cm', 'm', 'nm']
 
 energy_unit = {
     'FIELD_NAME': 'ENERGY_UNIT',
@@ -23,15 +16,7 @@ energy_unit = {
     'field_name': 'energy_unit',
 }
 
-energy_attributes = [
-    'unused',
-    'amu_A2_per_ps2',
-    'erg',
-    'eV',
-    'Hartree',
-    'J',
-    'kcal_mol'
-]
+energy_attributes = ['unused', 'amu_A2_per_ps2', 'erg', 'eV', 'Hartree', 'J', 'kcal_mol']
 
 charge_unit = {
     'FIELD_NAME': 'CHARGE_UNIT',
@@ -40,12 +25,7 @@ charge_unit = {
     'field_name': 'charge_unit',
 }
 
-charge_attributes = [
-    'unused',
-    'C',
-    'e',
-    'statC'
-]
+charge_attributes = ['unused', 'C', 'e', 'statC']
 
 temperature_unit = {
     'FIELD_NAME': 'TEMPERATURE_UNIT',
@@ -54,10 +34,7 @@ temperature_unit = {
     'field_name': 'temperature_unit',
 }
 
-temperature_attributes = [
-    'unused',
-    'K'
-]
+temperature_attributes = ['unused', 'K']
 
 time_unit = {
     'FIELD_NAME': 'TIME_UNIT',
@@ -66,21 +43,9 @@ time_unit = {
     'field_name': 'time_unit',
 }
 
-time_attributes = [
-    'unused',
-    'fs',
-    'ps',
-    'ns',
-    's'
-]
+time_attributes = ['unused', 'fs', 'ps', 'ns', 's']
 
-all_units = [
-    length_unit,
-    energy_unit,
-    charge_unit,
-    temperature_unit,
-    time_unit
-]
+all_units = [length_unit, energy_unit, charge_unit, temperature_unit, time_unit]
 
 all_attributes = [
     length_attributes,

--- a/scripts/generate_UnitSystem_bind_test.py
+++ b/scripts/generate_UnitSystem_bind_test.py
@@ -3,7 +3,7 @@ from generate_bind_test_commons import generate_bind, generate_test
 length_unit = {
     'FIELD_NAME': 'LENGTH_UNIT',
     'FieldName': 'LengthUnit',
-    'filedName': 'lengthUnit',
+    'fieldName': 'lengthUnit',
     'field_name': 'length_unit',
 }
 
@@ -19,7 +19,7 @@ length_attributes = [
 energy_unit = {
     'FIELD_NAME': 'ENERGY_UNIT',
     'FieldName': 'EnergyUnit',
-    'filedName': 'energyUnit',
+    'fieldName': 'energyUnit',
     'field_name': 'energy_unit',
 }
 
@@ -36,7 +36,7 @@ energy_attributes = [
 charge_unit = {
     'FIELD_NAME': 'CHARGE_UNIT',
     'FieldName': 'ChargeUnit',
-    'filedName': 'chargeUnit',
+    'fieldName': 'chargeUnit',
     'field_name': 'charge_unit',
 }
 
@@ -50,7 +50,7 @@ charge_attributes = [
 temperature_unit = {
     'FIELD_NAME': 'TEMPERATURE_UNIT',
     'FieldName': 'TemperatureUnit',
-    'filedName': 'temperatureUnit',
+    'fieldName': 'temperatureUnit',
     'field_name': 'temperature_unit',
 }
 
@@ -62,7 +62,7 @@ temperature_attributes = [
 time_unit = {
     'FIELD_NAME': 'TIME_UNIT',
     'FieldName': 'TimeUnit',
-    'filedName': 'timeUnit',
+    'fieldName': 'timeUnit',
     'field_name': 'time_unit',
 }
 
@@ -73,7 +73,6 @@ time_attributes = [
     'ns',
     's'
 ]
-
 
 all_units = [
     length_unit,

--- a/scripts/generate_bind_test_commons.py
+++ b/scripts/generate_bind_test_commons.py
@@ -14,7 +14,7 @@ def generate_bind(fields, attributes):
       length_unit = {
         'FIELD_NAME': 'LENGTH_UNIT',
         'FieldName': 'LengthUnit',
-        'filedName': 'lengthUnit',
+        'fieldName': 'lengthUnit',
         'field_name': 'length_unit'}
 
     attributes: list of str
@@ -68,7 +68,7 @@ def generate_test(fields, attributes):
       length_unit = {
         'FIELD_NAME': 'LENGTH_UNIT',
         'FieldName': 'LengthUnit',
-        'filedName': 'lengthUnit',
+        'fieldName': 'lengthUnit',
         'field_name': 'length_unit'}
 
     attributes: list of str

--- a/scripts/test_field_name.py-template
+++ b/scripts/test_field_name.py-template
@@ -4,6 +4,7 @@ rpls_attributes
 
 rpls_str_names
 
+
 def test_main():
     """Main test function."""
     N = kimpy.field_name.get_number_of_field_names()

--- a/scripts/test_field_name.py-template
+++ b/scripts/test_field_name.py-template
@@ -6,23 +6,24 @@ rpls_str_names
 
 def test_main():
     """Main test function."""
-
     N = kimpy.field_name.get_number_of_field_names()
+
     assert N == rpls_num_attributes
 
     all_instances = []
     for i in range(N):
-        inst,error = kimpy.field_name.get_field_name(i)
+        inst = kimpy.field_name.get_field_name(i)
+
         all_instances.append(inst)
 
-        assert error == False
         assert inst == attributes[i]
         assert str(inst) == str_names[i]
 
     # test operator overloading
     for i in range(N):
         assert all_instances[i] == all_instances[i]
-        for j in range(i+1, N):
+
+        for j in range(i + 1, N):
             assert all_instances[i] != all_instances[j]
 
     # test known
@@ -30,8 +31,15 @@ def test_main():
         assert inst.known() == True
 
     # test out of bound
-    inst,error = kimpy.field_name.get_field_name(N)
-    assert error == True
+    capture_out_of_bound_error = False
+
+    try:
+        inst = kimpy.field_name.get_field_name(N)
+    except RuntimeError:
+        capture_out_of_bound_error = True
+
+    assert capture_out_of_bound_error
+
 
 if __name__ == '__main__':
     test_main()

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,6 @@ def generate_files():
     subprocess.call([sys.executable, generate_script])
 
 
-# Run scripts to generate files.
-generate_files()
-
-
 def inquire_kim_api(kim_api_key):
     """Get compile and link flags of kim-api package."""
     try:
@@ -84,11 +80,10 @@ def has_flag(compiler, flag_name):
     try:
         compiler.compile([tempfile_name], extra_postargs=[flag_name])
     except distutils.errors.CompileError:
-        print(
-            f"Checking whether the compiler supports flag: '{flag_name}'. You may see "
-            "compilation error (e.g. gcc: error: unrecognized command line option "
-            f"{flag_name}). Just ignore it; we are on the right track."
-        )
+        print(f"Checking whether the compiler supports flag: '{flag_name}'. "
+              "You may see compilation error (e.g. gcc: error: unrecognized "
+              f"command line option {flag_name}). Just ignore it; we are on "
+              "the right track.")
         return False
     finally:
         try:
@@ -111,10 +106,12 @@ def cpp_flag(compiler_type, compiler):
     for flag in flags:
         if has_flag(compiler, flag):
             return flag
+
     if compiler_type == "unix":
         msg = "Unsupported compiler -- at least C++11 support is needed!"
     else:
         msg = "Unsupported compiler -- at least C++17 support is needed!"
+
     raise Exception(msg)
 
 
@@ -182,7 +179,8 @@ def get_include_dirs():
     include_dirs = inquire_kim_api("--cflags-only-I")
     include_dirs.append(get_pybind_include())
     include_dirs.append(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "kimpy", "neighlist")
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     "kimpy", "neighlist")
     )
     return include_dirs
 
@@ -301,7 +299,9 @@ def chech_kim_api_compatibility():
         kim_api_version = modversion
 
     kimpy_version = get_kimpy_version()
-    kim_api_compatibility = check_kim_api_compatibility(kimpy_version, kim_api_version)
+    kim_api_compatibility = check_kim_api_compatibility(
+        kimpy_version, kim_api_version)
+
     if kim_api_compatibility is not None:
         raise Exception(kim_api_compatibility)
 
@@ -309,6 +309,8 @@ def chech_kim_api_compatibility():
 # Check kim-api compatibility
 chech_kim_api_compatibility()
 
+# Run scripts to generate files.
+generate_files()
 
 setup(
     name="kimpy",
@@ -318,8 +320,8 @@ setup(
     install_requires=["pybind11", "numpy", "pytest"],
     cmdclass={"build_ext": BuildExt},
     ext_modules=get_kimpy_ext_modules(),
-    author="Mingjian Wen",
-    author_email="wenxx151@gmail.com",
+    author="Mingjian Wen, Yaser Afshar",
+    author_email="wenxx151@gmail.com, yafshar@umn.edu",
     url="https://github.com/openkim/kimpy",
     description="Python interface to the KIM-API",
     long_description="Python interface to the KIM-API. For more "

--- a/setup.py
+++ b/setup.py
@@ -80,10 +80,12 @@ def has_flag(compiler, flag_name):
     try:
         compiler.compile([tempfile_name], extra_postargs=[flag_name])
     except distutils.errors.CompileError:
-        print(f"Checking whether the compiler supports flag: '{flag_name}'. "
-              "You may see compilation error (e.g. gcc: error: unrecognized "
-              f"command line option {flag_name}). Just ignore it; we are on "
-              "the right track.")
+        print(
+            f"Checking whether the compiler supports flag: '{flag_name}'. "
+            "You may see compilation error (e.g. gcc: error: unrecognized "
+            f"command line option {flag_name}). Just ignore it; we are on "
+            "the right track."
+        )
         return False
     finally:
         try:
@@ -179,8 +181,7 @@ def get_include_dirs():
     include_dirs = inquire_kim_api("--cflags-only-I")
     include_dirs.append(get_pybind_include())
     include_dirs.append(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     "kimpy", "neighlist")
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "kimpy", "neighlist")
     )
     return include_dirs
 
@@ -299,8 +300,7 @@ def chech_kim_api_compatibility():
         kim_api_version = modversion
 
     kimpy_version = get_kimpy_version()
-    kim_api_compatibility = check_kim_api_compatibility(
-        kimpy_version, kim_api_version)
+    kim_api_compatibility = check_kim_api_compatibility(kimpy_version, kim_api_version)
 
     if kim_api_compatibility is not None:
         raise Exception(kim_api_compatibility)

--- a/tests/neighlist/test_graphite.py
+++ b/tests/neighlist/test_graphite.py
@@ -101,14 +101,14 @@ def test_main():
     neigh = nl.create()
 
     try:
-        nl.build(neigh, coords, influence_dist, cutoffs, need_neigh)
+        neigh.build(coords, influence_dist, cutoffs, need_neigh)
     except RuntimeError:
         msg = 'Calling "neighlist.build" failed.'
         raise KimPyError(msg)
 
     # build again (it will automatically empty previous neigh list)
     try:
-        nl.build(neigh, coords, influence_dist, cutoffs, need_neigh)
+        neigh.build(coords, influence_dist, cutoffs, need_neigh)
     except RuntimeError:
         msg = 'Calling "neighlist.build" failed.'
         raise KimPyError(msg)
@@ -118,7 +118,7 @@ def test_main():
     particle = 1
 
     try:
-        num_neigh, _ = nl.get_neigh(neigh, cutoffs, neigh_list_index, particle)
+        num_neigh, _ = neigh.get_neigh(cutoffs, neigh_list_index, particle)
     except RuntimeError:
         msg = 'KIM error. Calling "neighlist.get_neigh" failed.'
         raise KimPyError(msg)
@@ -129,7 +129,7 @@ def test_main():
     particle = 4
 
     try:
-        num_neigh, _ = nl.get_neigh(neigh, cutoffs, neigh_list_index, particle)
+        num_neigh, _ = neigh.get_neigh(cutoffs, neigh_list_index, particle)
     except RuntimeError:
         msg = 'KIM error. Calling "neighlist.get_neigh" failed.'
         raise KimPyError(msg)

--- a/tests/neighlist/test_graphite.py
+++ b/tests/neighlist/test_graphite.py
@@ -72,12 +72,9 @@ def test_main():
     pbc = np.array([1, 1, 1], dtype=np.intc)
 
     try:
-        pad_coords, pad_species, _ = \
-            nl.create_paddings(influence_dist,
-                               cell,
-                               pbc,
-                               contrib_coords,
-                               contrib_species)
+        pad_coords, pad_species, _ = nl.create_paddings(
+            influence_dist, cell, pbc, contrib_coords, contrib_species
+        )
     except RuntimeError:
         msg = 'Calling "neighlist.create_paddings" failed.'
         raise KimPyError(msg)
@@ -121,8 +118,7 @@ def test_main():
     particle = 1
 
     try:
-        num_neigh, _ = \
-            nl.get_neigh(neigh, cutoffs, neigh_list_index, particle)
+        num_neigh, _ = nl.get_neigh(neigh, cutoffs, neigh_list_index, particle)
     except RuntimeError:
         msg = 'KIM error. Calling "neighlist.get_neigh" failed.'
         raise KimPyError(msg)

--- a/tests/neighlist/test_graphite.py
+++ b/tests/neighlist/test_graphite.py
@@ -1,24 +1,23 @@
 import os
 import numpy as np
+
 from kimpy import neighlist as nl
-from kimpy import check_error
+from kimpy import KimPyError
 
 
 def create_graphite_unit_cell(alat=2.46, d=3.35):
 
-    cell = np.zeros(9).reshape(3, 3)
+    cell = np.zeros((3, 3), dtype=np.double)
     cell[0][0] = alat
     cell[1][0] = 0.5 * alat
     cell[1][1] = np.sqrt(3) * 0.5 * alat
     cell[2][2] = 2 * d
-    cell = np.asarray(cell, dtype=np.double)
 
-    coords = []
-    coords.append([0, 0, 0])
-    coords.append(cell[0] / 3.0 + cell[1] / 3.0)
-    coords.append(cell[0] / 3.0 + cell[1] / 3.0 + cell[2] / 2.0)
-    coords.append(cell[0] * 2 / 3.0 + cell[1] * 2 / 3.0 + cell[2] / 2.0)
-    coords = np.asarray(coords, dtype=np.double)
+    coords = np.empty((4, 3), dtype=np.double)
+    coords[0] = np.zeros((3), dtype=np.double)
+    coords[1] = (cell[0] + cell[1]) / 3.0
+    coords[2] = (cell[0] + cell[1]) / 3.0 + cell[2] / 2.0
+    coords[3] = (cell[0] + cell[1]) * 2 / 3.0 + cell[2] / 2.0
 
     species = np.array([1, 1, 2, 2], dtype=np.intc)
 
@@ -39,6 +38,7 @@ def write_XYZ(fname, lat_vec, species, coords):
         for line in lat_vec:
             for item in line:
                 fout.write('{:.15g} '.format(item))  # g removes trailing zero
+
         fout.write('" ')
         # PBC
         fout.write('PBC="1 1 1" ')
@@ -61,68 +61,84 @@ def test_main():
     # create contributing atoms
     alat = 2.46
     d = 3.35
+
     cell, contrib_coords, contrib_species = create_graphite_unit_cell(alat, d)
 
     # create padding atoms
     cutoffs = np.array([d + 0.01, d + 0.02], dtype=np.double)
+
     influence_dist = cutoffs[1]
+
     pbc = np.array([1, 1, 1], dtype=np.intc)
-    out = nl.create_paddings(influence_dist, cell, pbc,
-                             contrib_coords, contrib_species)
-    pad_coords, pad_species, pad_image, error = out
-    check_error(error, 'nl.create_padding')
+
+    try:
+        pad_coords, pad_species, _ = \
+            nl.create_paddings(influence_dist,
+                               cell,
+                               pbc,
+                               contrib_coords,
+                               contrib_species)
+    except RuntimeError:
+        msg = 'Calling "neighlist.create_paddings" failed.'
+        raise KimPyError(msg)
 
     assert pad_coords.shape == (96, 3)
-    # print('pad_coords is of shape:', pad_coords.shape)
 
     coords = np.concatenate((contrib_coords, pad_coords))
     coords = np.asarray(coords, dtype=np.double)
+
     species = np.concatenate((contrib_species, pad_species))
     species = np.asarray(species, dtype=np.intc)
+
     fname = 'atoms.xyz'
     write_XYZ(fname, cell, species, coords)
 
     # flag to indicate wheter create neighbor list for an atom
     n_pad = pad_coords.shape[0]
     n_contrib = contrib_coords.shape[0]
+
     need_neigh = np.concatenate((np.ones(n_contrib), np.zeros(n_pad)))
     need_neigh = np.asarray(need_neigh, dtype=np.intc)
 
     # create neighbor list
-    neigh = nl.initialize()
-    error = nl.build(neigh, coords, influence_dist, cutoffs, need_neigh)
-    check_error(error, 'nl.build')
+    neigh = nl.create()
+
+    try:
+        nl.build(neigh, coords, influence_dist, cutoffs, need_neigh)
+    except RuntimeError:
+        msg = 'Calling "neighlist.build" failed.'
+        raise KimPyError(msg)
 
     # build again (it will automatically empty previous neigh list)
-    error = nl.build(neigh, coords, influence_dist, cutoffs, need_neigh)
-    check_error(error, 'nl.build')
+    try:
+        nl.build(neigh, coords, influence_dist, cutoffs, need_neigh)
+    except RuntimeError:
+        msg = 'Calling "neighlist.build" failed.'
+        raise KimPyError(msg)
 
     # test get neigh function
     neigh_list_index = 0
     particle = 1
-    num_neigh, neighbors, error = nl.get_neigh(
-        neigh, cutoffs, neigh_list_index, particle)
-    check_error(error, 'nl.get_neigh')
+
+    try:
+        num_neigh, _ = \
+            nl.get_neigh(neigh, cutoffs, neigh_list_index, particle)
+    except RuntimeError:
+        msg = 'KIM error. Calling "neighlist.get_neigh" failed.'
+        raise KimPyError(msg)
+
     assert num_neigh == 14
-    # print('Atom 1 has {} neighbors:'.format(num_neigh), end=' ')
-    # for i in neighbors:
-    #  print(i, end=' ')
 
     neigh_list_index = 1
     particle = 4
-    num_neigh, neighbors, error = nl.get_neigh(
-        neigh, cutoffs, neigh_list_index, particle)
-    check_error(error, 'nl.get_neigh')
+
+    try:
+        num_neigh, _ = nl.get_neigh(neigh, cutoffs, neigh_list_index, particle)
+    except RuntimeError:
+        msg = 'KIM error. Calling "neighlist.get_neigh" failed.'
+        raise KimPyError(msg)
+
     assert num_neigh == 0
-
-    # expect error message from this
-    # neigh_list_index = 1
-    # particle = n_contrib + n_pad
-    # num_neigh, neighbors, error = nl.get_neigh(neigh, cutoffs, neigh_list_index, particle)
-    # assert error == 1
-
-    # delete neighbor list
-    nl.clean(neigh)
 
     # remove the created file
     try:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -22,10 +22,9 @@ import pytest
 
 # create a dimer of two atoms
 def get_argon_dimer():
-    argon = Atoms('ArAr',
-                  positions=[(0, 0, 0), (0.1, 0.2, 0.2)],
-                  cell=(10, 10, 10),
-                  pbc=(0, 0, 0))
+    argon = Atoms(
+        'ArAr', positions=[(0, 0, 0), (0.1, 0.2, 0.2)], cell=(10, 10, 10), pbc=(0, 0, 0)
+    )
     return argon
 
 
@@ -147,7 +146,8 @@ def test_main():
             kimpy.charge_unit.e,
             kimpy.temperature_unit.K,
             kimpy.time_unit.ps,
-            model_name)
+            model_name,
+        )
     except RuntimeError:
         raise kimpy.KimPyError('Calling "kimpy.model.create" failed.')
 
@@ -175,51 +175,57 @@ def test_main():
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.numberOfParticles, num_particles)
+            kimpy.compute_argument_name.numberOfParticles, num_particles
+        )
     except RuntimeError:
         msg = 'Calling "compute_argument.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.particleSpeciesCodes, species_code)
+            kimpy.compute_argument_name.particleSpeciesCodes, species_code
+        )
     except RuntimeError:
         msg = 'Calling "compute_argument.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.particleContributing,
-            particle_contributing)
+            kimpy.compute_argument_name.particleContributing, particle_contributing
+        )
     except RuntimeError:
         msg = 'Calling "compute_argument.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.coordinates, coords)
+            kimpy.compute_argument_name.coordinates, coords
+        )
     except RuntimeError:
         msg = 'Calling "compute_argument.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.partialEnergy, energy)
+            kimpy.compute_argument_name.partialEnergy, energy
+        )
     except RuntimeError:
         msg = 'Calling "compute_argument.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.partialForces, forces)
+            kimpy.compute_argument_name.partialForces, forces
+        )
     except RuntimeError:
         msg = 'Calling "compute_argument.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     # species support and code
     try:
-        species_support, code = \
-            kim_model.get_species_support_and_code(kimpy.species_name.Ar)
+        species_support, code = kim_model.get_species_support_and_code(
+            kimpy.species_name.Ar
+        )
     except RuntimeError:
         msg = 'Calling "kim_model.get_species_support_and_code" failed.'
         raise kimpy.KimPyError(msg)
@@ -237,24 +243,24 @@ def test_main():
     # register callbacks
     try:
         compute_arguments.set_callback(
-            kimpy.compute_callback_name.GetNeighborList,
-            get_neigh, neigh_data)
+            kimpy.compute_callback_name.GetNeighborList, get_neigh, neigh_data
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_callback" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_callback(
-            kimpy.compute_callback_name.ProcessDEDrTerm,
-            process_dEdr, dEdr_data)
+            kimpy.compute_callback_name.ProcessDEDrTerm, process_dEdr, dEdr_data
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_callback" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_callback(
-            kimpy.compute_callback_name.ProcessD2EDr2Term,
-            process_d2Edr2, d2Edr2_data)
+            kimpy.compute_callback_name.ProcessD2EDr2Term, process_d2Edr2, d2Edr2_data
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_callback" failed.'
         raise kimpy.KimPyError(msg)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,19 +1,21 @@
 """ Test callbacks can pass data bi-directionally.
 
-Two atoms are in the configuration, and as a results, each time `kim_model.compute`
-is issued, callback `get_neigh` is called twice, but `process_dEdr` and
-`process_d2Edr2` are called only once since the LJ612 model uses half list.
+Two atoms are in the configuration, and as a results, each time
+`kim_model.compute` is issued, callback `get_neigh` is called twice, but
+`process_dEdr` and `process_d2Edr2` are called only once since the LJ612 model
+uses half list.
 
-In this test, we call `kim_model.compute` twice. After the first call, we change
-the local data to test that we can modifiy data locally and the modification
-goes to the data object in the KIM API. Similary, we test the data modified in the
-KIM KPI is reflected locally by changing the data in the callbacks when it is last
-called.
+In this test, we call `kim_model.compute` twice.
+
+After the first call, we change the local data to test that we can modifiy data
+locally and the modification goes to the data object in the KIM API. Similary,
+we test the data modified in the KIM KPI is reflected locally by changing the
+data in the callbacks when it is last called.
+
 """
 
 import numpy as np
 import kimpy
-from kimpy import check_error, report_error
 from ase import Atoms
 import pytest
 
@@ -47,24 +49,30 @@ neigh_data['num_called'] = 0
 
 
 def get_neigh(data, cutoffs, neighbor_list_index, particle_number):
-    if data['num_called'] < 2:  # 1st call of kim_model.compute
+    # 1st call of kim_model.compute
+    if data['num_called'] < 2:
         assert data['cutoff'] == pytest.approx(1.0, 1e-6)
         assert data['num_particles'] == 2
         assert_2d_array(data['neighbors'], [[1], [0]])
         assert data['key'] == 1
-    else:  # 2nd call of kim_model.compute
+    # 2nd call of kim_model.compute
+    else:
         assert data['cutoff'] == pytest.approx(1.0, 1e-6)
         assert data['num_particles'] == 2
         assert_2d_array(data['neighbors'], [[1], [0]])
         assert data['key'] == 2
 
-    if data['num_called'] == 3:  # last call of this function
-        data['key'] = 3  # modify original key
-        data['new_key'] = 1  # add new key
+    # last call of this function
+    if data['num_called'] == 3:
+        # modify original key
+        data['key'] = 3
+        # add new key
+        data['new_key'] = 1
+
     data['num_called'] += 1
-    error = 0
     neighbors = data['neighbors'][particle_number]
-    return (neighbors, error)
+
+    return (neighbors, 0)
 
 
 # process dEdr
@@ -77,17 +85,24 @@ n_dEdr_called = 0
 
 def process_dEdr(data, de, r, dx, i, j):
     assert r == pytest.approx(0.3, 1e-6)
+
     assert_1d_array(abs(dx), [0.1, 0.2, 0.2])
-    if data['num_called'] < 1:  # 1st call of kim_model.compute
+
+    # 1st call of kim_model.compute
+    if data['num_called'] < 1:
         assert data['key'] == 1
     else:
         assert data['key'] == 2
-    if data['num_called'] == 1:  # last call of this function
-        data['key'] = 3  # modify original key
-        data['new_key'] = 1  # add new key
+
+    # last call of this function
+    if data['num_called'] == 1:
+        # modify original key
+        data['key'] = 3
+        # add new key
+        data['new_key'] = 1
+
     data['num_called'] += 1
-    error = 0
-    return error
+    return 0
 
 
 # process d2Edr2
@@ -98,41 +113,54 @@ d2Edr2_data['num_called'] = 0
 
 def process_d2Edr2(data, de, r, dx, i, j):
     assert_1d_array(r, [0.3, 0.3])
+
     assert_1d_array(abs(dx), [0.1, 0.2, 0.2, 0.1, 0.2, 0.2])
-    if data['num_called'] < 1:  # 1st call of kim_model.compute
+
+    # 1st call of kim_model.compute
+    if data['num_called'] < 1:
         assert data['key'] == 1
     else:
         assert data['key'] == 2
-    if data['num_called'] == 1:  # last call of this function
-        data['key'] = 3  # modify original key
-        data['new_key'] = 1  # add new key
+
+    # last call of this function
+    if data['num_called'] == 1:
+        # modify original key
+        data['key'] = 3
+        # add new key
+        data['new_key'] = 1
+
     data['num_called'] += 1
-    error = 0
-    return error
+
+    return 0
 
 
 def test_main():
 
-    modelname = 'LennardJones612_UniversalShifted__MO_959249795837_003'
+    model_name = 'LennardJones612_UniversalShifted__MO_959249795837_003'
 
     # create model
-    requestedUnitsAccepted, kim_model, error = kimpy.model.create(
-        kimpy.numbering.zeroBased,
-        kimpy.length_unit.A,
-        kimpy.energy_unit.eV,
-        kimpy.charge_unit.e,
-        kimpy.temperature_unit.K,
-        kimpy.time_unit.ps,
-        modelname,
-    )
-    check_error(error, 'kimpy.model.create')
+    try:
+        requested_units_accepted, kim_model = kimpy.model.create(
+            kimpy.numbering.zeroBased,
+            kimpy.length_unit.A,
+            kimpy.energy_unit.eV,
+            kimpy.charge_unit.e,
+            kimpy.temperature_unit.K,
+            kimpy.time_unit.ps,
+            model_name)
+    except RuntimeError:
+        raise kimpy.KimPyError('Calling "kimpy.model.create" failed.')
 
-    if not requestedUnitsAccepted:
-        report_error('requested units not accepted in kimpy.model.create')
+    if not requested_units_accepted:
+        msg = 'requested units not accepted in kimpy.model.create'
+        raise kimpy.KimPyError(msg)
 
     # create compute arguments
-    compute_arguments, error = kim_model.compute_arguments_create()
-    check_error(error, 'kim_model.compute_arguments_create')
+    try:
+        compute_arguments = kim_model.compute_arguments_create()
+    except RuntimeError:
+        msg = 'Calling "kim_model.compute_arguments_create" failed.'
+        raise kimpy.KimPyError(msg)
 
     # register argument
     argon = get_argon_dimer()
@@ -145,41 +173,60 @@ def test_main():
     species_code = np.zeros(num_particles, dtype=np.intc)
     particle_contributing = np.zeros(num_particles, dtype=np.intc)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.numberOfParticles,
-        num_particles)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.numberOfParticles, num_particles)
+    except RuntimeError:
+        msg = 'Calling "compute_argument.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.particleSpeciesCodes,
-        species_code)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.particleSpeciesCodes, species_code)
+    except RuntimeError:
+        msg = 'Calling "compute_argument.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.particleContributing,
-        particle_contributing)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.particleContributing,
+            particle_contributing)
+    except RuntimeError:
+        msg = 'Calling "compute_argument.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.coordinates,
-        coords)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.coordinates, coords)
+    except RuntimeError:
+        msg = 'Calling "compute_argument.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.partialEnergy,
-        energy)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.partialEnergy, energy)
+    except RuntimeError:
+        msg = 'Calling "compute_argument.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.partialForces,
-        forces)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.partialForces, forces)
+    except RuntimeError:
+        msg = 'Calling "compute_argument.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
     # species support and code
-    species_support, code, error = \
-        kim_model.get_species_support_and_code(kimpy.species_name.Ar)
-    check_error(error or not species_support,
-                'kim_model.get_species_support_and_code')
+    try:
+        species_support, code = \
+            kim_model.get_species_support_and_code(kimpy.species_name.Ar)
+    except RuntimeError:
+        msg = 'Calling "kim_model.get_species_support_and_code" failed.'
+        raise kimpy.KimPyError(msg)
+
+    if not species_support:
+        msg = 'Ar species is not supported by this model.'
+        raise kimpy.KimPyError(msg)
 
     # setup particle species
     species_code[:] = code
@@ -188,36 +235,47 @@ def test_main():
     particle_contributing[:] = 1
 
     # register callbacks
-    error = compute_arguments.set_callback(
-        kimpy.compute_callback_name.GetNeighborList,
-        get_neigh, neigh_data)
-    check_error(error, 'kimpy.compute_argument.set_callback')
+    try:
+        compute_arguments.set_callback(
+            kimpy.compute_callback_name.GetNeighborList,
+            get_neigh, neigh_data)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_callback" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_callback(
-        kimpy.compute_callback_name.ProcessDEDrTerm,
-        process_dEdr, dEdr_data)
-    check_error(error, 'kimpy.compute_argument.set_callback')
+    try:
+        compute_arguments.set_callback(
+            kimpy.compute_callback_name.ProcessDEDrTerm,
+            process_dEdr, dEdr_data)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_callback" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_callback(
-        kimpy.compute_callback_name.ProcessD2EDr2Term,
-        process_d2Edr2, d2Edr2_data)
-    check_error(error, 'kimpy.compute_argument.set_callback')
+    try:
+        compute_arguments.set_callback(
+            kimpy.compute_callback_name.ProcessD2EDr2Term,
+            process_d2Edr2, d2Edr2_data)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_callback" failed.'
+        raise kimpy.KimPyError(msg)
 
     # 1st call of compute
-    error = kim_model.compute(compute_arguments)
-    check_error(error, 'kim_model.compute')
+    try:
+        kim_model.compute(compute_arguments)
+    except RuntimeError:
+        msg = 'Calling "kim_model.compute" failed the 1st time.'
+        raise kimpy.KimPyError(msg)
 
     # 2nd call of compute
     neigh_data['key'] = 2
     dEdr_data['key'] = 2
     d2Edr2_data['key'] = 2
-    error = kim_model.compute(compute_arguments)
-    check_error(error, 'kim_model.compute')
 
-    # destory compute arguments and model
-    error = kim_model.compute_arguments_destroy(compute_arguments)
-    check_error(error, 'kim_model.compute_arguments_destroy')
-    kimpy.model.destroy(kim_model)
+    try:
+        kim_model.compute(compute_arguments)
+    except RuntimeError:
+        msg = 'Calling "kim_model.compute" failed the 2nd time.'
+        raise kimpy.KimPyError(msg)
 
     # check callback can modify local data
     assert neigh_data['key'] == 3

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -28,16 +28,6 @@ def get_argon_dimer():
     return argon
 
 
-def assert_1d_array(array_a, array_b):
-    assert len(array_a) == len(array_b)
-    for i, j in zip(array_a, array_b):
-        assert i == pytest.approx(j, 1e-6)
-
-
-def assert_2d_array(array_a, array_b):
-    assert np.allclose(array_a, array_b)
-
-
 # neigh
 neigh_data = dict()
 neigh_data['cutoff'] = 1.0
@@ -52,13 +42,13 @@ def get_neigh(data, cutoffs, neighbor_list_index, particle_number):
     if data['num_called'] < 2:
         assert data['cutoff'] == pytest.approx(1.0, 1e-6)
         assert data['num_particles'] == 2
-        assert_2d_array(data['neighbors'], [[1], [0]])
+        assert np.allclose(data['neighbors'], [[1], [0]])
         assert data['key'] == 1
     # 2nd call of kim_model.compute
     else:
         assert data['cutoff'] == pytest.approx(1.0, 1e-6)
         assert data['num_particles'] == 2
-        assert_2d_array(data['neighbors'], [[1], [0]])
+        assert np.allclose(data['neighbors'], [[1], [0]])
         assert data['key'] == 2
 
     # last call of this function
@@ -85,7 +75,7 @@ n_dEdr_called = 0
 def process_dEdr(data, de, r, dx, i, j):
     assert r == pytest.approx(0.3, 1e-6)
 
-    assert_1d_array(abs(dx), [0.1, 0.2, 0.2])
+    assert np.allclose(abs(dx), [0.1, 0.2, 0.2])
 
     # 1st call of kim_model.compute
     if data['num_called'] < 1:
@@ -111,9 +101,10 @@ d2Edr2_data['num_called'] = 0
 
 
 def process_d2Edr2(data, de, r, dx, i, j):
-    assert_1d_array(r, [0.3, 0.3])
 
-    assert_1d_array(abs(dx), [0.1, 0.2, 0.2, 0.1, 0.2, 0.2])
+    assert np.allclose(r, [0.3, 0.3])
+
+    assert np.allclose(abs(dx), [0.1, 0.2, 0.2, 0.1, 0.2, 0.2])
 
     # 1st call of kim_model.compute
     if data['num_called'] < 1:

--- a/tests/test_compute_argument_name.py
+++ b/tests/test_compute_argument_name.py
@@ -43,16 +43,27 @@ def test_main():
 
     all_instances = []
     for i in range(N):
-        inst, error = kimpy.compute_argument_name.get_compute_argument_name(i)
-        assert not error
+        try:
+            inst = kimpy.compute_argument_name.get_compute_argument_name(i)
+        except RuntimeError:
+            msg = 'Calling "kimpy.compute_argument_name.'
+            msg += 'get_compute_argument_name" failed.'
+            raise kimpy.KimPyError(msg)
+
         assert inst == attributes[i]
         assert str(inst) == str_names[i]
 
         all_instances.append(inst)
 
-        dtype, error = \
-            kimpy.compute_argument_name.get_compute_argument_data_type(inst)
-        assert not error
+        try:
+            dtype = \
+                kimpy.compute_argument_name.get_compute_argument_data_type(
+                    inst)
+        except RuntimeError:
+            msg = 'Calling "kimpy.compute_argument_name.'
+            msg += 'get_compute_argument_data_type" failed.'
+            raise kimpy.KimPyError(msg)
+
         assert dtype == data_types[i]
 
     # test operator overloading
@@ -66,8 +77,14 @@ def test_main():
         assert inst.known()
 
     # test out of bound
-    inst, error = kimpy.compute_argument_name.get_compute_argument_name(N)
-    assert error
+    capture_out_of_bound_error = False
+
+    try:
+        inst = kimpy.compute_argument_name.get_compute_argument_name(N)
+    except RuntimeError:
+        capture_out_of_bound_error = True
+
+    assert capture_out_of_bound_error
 
 
 if __name__ == '__main__':

--- a/tests/test_compute_argument_name.py
+++ b/tests/test_compute_argument_name.py
@@ -56,9 +56,7 @@ def test_main():
         all_instances.append(inst)
 
         try:
-            dtype = \
-                kimpy.compute_argument_name.get_compute_argument_data_type(
-                    inst)
+            dtype = kimpy.compute_argument_name.get_compute_argument_data_type(inst)
         except RuntimeError:
             msg = 'Calling "kimpy.compute_argument_name.'
             msg += 'get_compute_argument_data_type" failed.'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
 import kimpy
-from kimpy import check_error, report_error
 from ase.lattice.cubic import FaceCenteredCubic
 
 
@@ -21,16 +20,21 @@ def get_neigh(data, cutoffs, neighbor_list_index, particle_number):
 
     # we only support one neighbor list
     rcut = data['cutoff']
+
     if len(cutoffs) != 1 or cutoffs[0] > rcut:
         error = 1
+
     if neighbor_list_index != 0:
         error = 1
 
     # invalid id
     number_of_particles = data['num_particles']
+
     if particle_number >= number_of_particles or particle_number < 0:
         error = 1
-    check_error(error, 'get_neigh')
+
+    if error == 1:
+        raise kimpy.KimPyError('Calling "get_neigh" failed.')
 
     neighbors = data['neighbors'][particle_number]
     return (neighbors, error)
@@ -58,32 +62,36 @@ def create_neigh(coords, cutoff, neigh):
 
 
 def test_main():
-
     modelname = 'ex_model_Ar_P_Morse'
+
     # modelname = 'Three_Body_Stillinger_Weber_Si__MO_405512056662_004'
     # modelname = 'LennardJones612_Universal__MO_826355984548_002'
+
     print()
     print('=' * 80)
     print('Matching results for KIM model:', modelname)
     print()
 
     # create model
-    requestedUnitsAccepted, kim_model, error = kimpy.model.create(
-        kimpy.numbering.zeroBased,
-        kimpy.length_unit.A,
-        kimpy.energy_unit.eV,
-        kimpy.charge_unit.e,
-        kimpy.temperature_unit.K,
-        kimpy.time_unit.ps,
-        modelname,
-    )
-    check_error(error, 'kimpy.model.create')
+    try:
+        requestedUnitsAccepted, kim_model = kimpy.model.create(
+            kimpy.numbering.zeroBased,
+            kimpy.length_unit.A,
+            kimpy.energy_unit.eV,
+            kimpy.charge_unit.e,
+            kimpy.temperature_unit.K,
+            kimpy.time_unit.ps,
+            modelname)
+    except RuntimeError:
+        raise kimpy.KimPyError('Calling "kimpy.model.create" failed.')
+
     if not requestedUnitsAccepted:
-        report_error('requested units not accepted in kimpy.model.create')
+        msg = 'requested units not accepted in kimpy.model.create'
+        raise kimpy.KimPyError(msg)
 
     # units
     l_unit, e_unit, c_unit, te_unit, ti_unit = kim_model.get_units()
-    check_error(error, 'kim_model.get_units')
+
     print('Length unit is:', str(l_unit))
     print('Energy unit is:', str(e_unit))
     print('Charge unit is:', str(c_unit))
@@ -92,31 +100,47 @@ def test_main():
     print()
 
     # create compute arguments
-    compute_arguments, error = kim_model.compute_arguments_create()
-    check_error(error, 'kim_model.compute_arguments_create')
+    try:
+        compute_arguments = kim_model.compute_arguments_create()
+    except RuntimeError:
+        msg = 'Calling "kim_model.compute_arguments_create" failed.'
+        raise kimpy.KimPyError(msg)
 
     # check compute arguments
-    num_compute_arguments = (
+    num_compute_arguments = \
         kimpy.compute_argument_name.get_number_of_compute_argument_names()
-    )
     print('Number of compute_arguments:', num_compute_arguments)
 
     for i in range(num_compute_arguments):
+        try:
+            name = kimpy.compute_argument_name.get_compute_argument_name(i)
+        except RuntimeError:
+            msg = 'Calling "kimpy.compute_argument_name.'
+            msg += 'get_compute_argument_name" for index = '
+            msg += '{} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
 
-        name, error = \
-            kimpy.compute_argument_name.get_compute_argument_name(i)
-        check_error(error, 'kim_model.get_compute_argument_name')
+        try:
+            dtype = \
+                kimpy.compute_argument_name.get_compute_argument_data_type(
+                    name)
+        except RuntimeError:
+            msg = 'Calling "kimpy.compute_argument_name.'
+            msg += 'get_compute_argument_data_type" for computeArgumentName = '
+            msg += '{} failed.'.format(name)
+            raise kimpy.KimPyError(msg)
 
-        dtype, error = \
-            kimpy.compute_argument_name.get_compute_argument_data_type(name)
-        check_error(error, 'kim_model.get_compute_argument_data_type')
-
-        support_status, error = \
-            compute_arguments.get_argument_support_status(name)
-        check_error(error, 'compute_argument.get_argument_support_status')
+        try:
+            support_status = \
+                compute_arguments.get_argument_support_status(name)
+        except RuntimeError:
+            msg = 'Calling "compute_arguments.get_argument_support_status" '
+            msg += 'for computeArgumentName = {} failed.'.format(name)
+            raise kimpy.KimPyError(msg)
 
         n_space_1 = 21 - len(str(name))
         n_space_2 = 7 - len(str(dtype))
+
         print(
             'Compute Argument name "{}" '.format(name)
             + ' ' * n_space_1
@@ -129,31 +153,44 @@ def test_main():
         if support_status == kimpy.support_status.required:
             if name not in (kimpy.compute_argument_name.partialEnergy,
                             kimpy.compute_argument_name.partialForces):
-                report_error('Unsupported required ComputeArgument')
+                msg = 'Unsupported required ComputeArgumentName = '
+                msg += '{}'.format(name)
+                raise kimpy.KimPyError(msg)
 
         # must have energy and forces
         if name in (kimpy.compute_argument_name.partialEnergy,
                     kimpy.compute_argument_name.partialForces):
             if support_status not in (kimpy.support_status.required,
                                       kimpy.support_status.optional):
-                report_error('Energy or forces not available')
+                raise kimpy.KimPyError('Energy or forces not available')
+
     print()
 
     # check compute callbacks
     num_callbacks = \
         kimpy.compute_callback_name.get_number_of_compute_callback_names()
+
     print('Number of callbacks:', num_callbacks)
 
     for i in range(num_callbacks):
+        try:
+            name = kimpy.compute_callback_name.get_compute_callback_name(i)
+        except RuntimeError:
+            msg = 'Calling "kimpy.compute_callback_name.'
+            msg += 'get_compute_callback_name" for index = '
+            msg += '{} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
 
-        name, error = kimpy.compute_callback_name.get_compute_callback_name(i)
-        check_error(error, 'kim_model.get_compute_callback_name')
-
-        support_status, error = \
-            compute_arguments.get_callback_support_status(name)
-        check_error(error, 'compute_argument.get_callback_support_status')
+        try:
+            support_status = \
+                compute_arguments.get_callback_support_status(name)
+        except RuntimeError:
+            msg = 'Calling "compute_arguments.get_callback_support_status" '
+            msg += 'for computeArgumentName = {} failed.'.format(name)
+            raise kimpy.KimPyError(msg)
 
         n_space = 18 - len(str(name))
+
         print(
             'Compute callback "{}"'.format(name)
             + ' ' * n_space
@@ -162,23 +199,32 @@ def test_main():
 
         # cannot handle any "required" callbacks
         if support_status == kimpy.support_status.required:
-            report_error('Unsupported required ComputeCallback')
+            raise kimpy.KimPyError('Unsupported required ComputeCallback')
+
     print()
 
     # parameter
     num_params = kim_model.get_number_of_parameters()
+
     print('Number of parameters:', num_params)
+
     print()
 
     for i in range(num_params):
-        out = kim_model.get_parameter_metadata(i)
-        dtype, extent, name, description, error = out
-        check_error(error, 'kim_model.get_parameter_metadata')
+        try:
+            dtype, extent, name, description = \
+                kim_model.get_parameter_metadata(i)
+        except RuntimeError:
+            msg = 'Calling "kim_model.get_parameter_metadata" '
+            msg += 'for parameterIndex = {} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
+
         print('Parameter No.', i)
         print('    data type:', dtype)
         print('    extent:', extent)
         print('    name:', name)
         print('    description:', description)
+
     print()
 
     # register argument
@@ -193,56 +239,82 @@ def test_main():
     species_code = np.zeros(num_particles, dtype=np.intc)
     particle_contributing = np.zeros(num_particles, dtype=np.intc)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.numberOfParticles,
-        num_particles)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.numberOfParticles, num_particles)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.particleSpeciesCodes,
-        species_code)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.particleSpeciesCodes, species_code)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.particleContributing,
-        particle_contributing)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.particleContributing,
+            particle_contributing)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.coordinates, coords)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.coordinates, coords)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.partialEnergy, energy)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.partialEnergy, energy)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.partialForces, forces)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.partialForces, forces)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
     # neighbor list
     neigh = dict()
 
     # register get neigh callback
-    error = compute_arguments.set_callback(
-        kimpy.compute_callback_name.GetNeighborList, get_neigh, neigh)
-    check_error(error, 'kimpy.compute_argument.set_callback')
+    try:
+        compute_arguments.set_callback(
+            kimpy.compute_callback_name.GetNeighborList, get_neigh, neigh)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_callback" failed.'
+        raise kimpy.KimPyError(msg)
 
     # influence distance and cutoff of model
     model_influence_dist = kim_model.get_influence_distance()
-    out = kim_model.get_neighbor_list_cutoffs_and_hints()
-    model_cutoffs, padding_not_require_neigh_hints = out
     print('Model influence distance:', model_influence_dist)
+
+    model_cutoffs, padding_not_require_neigh_hints = \
+        kim_model.get_neighbor_list_cutoffs_and_hints()
     print('Model cutoffs:', model_cutoffs)
     print('Model padding neighbors hints:', padding_not_require_neigh_hints)
     print()
 
     # species support and code
-    species_support, code, error = kim_model.get_species_support_and_code(
-        kimpy.species_name.Ar
-    )
-    check_error(error or not species_support,
-                'kim_model.get_species_support_and_code')
+    try:
+        species_support, code = \
+            kim_model.get_species_support_and_code(kimpy.species_name.Ar)
+    except RuntimeError:
+        msg = 'Calling "kim_model.get_species_support_and_code" failed.'
+        raise kimpy.KimPyError(msg)
+
+    if not species_support:
+        msg = 'Ar species is not supported by this model.'
+        raise kimpy.KimPyError(msg)
+
     print('Species Ar is supported and its code is:', code)
     print()
 
@@ -267,34 +339,41 @@ def test_main():
 
     for a in all_alat:
         argon = create_fcc_argon(a)
+
         # NOTE should not change coords address
         np.copyto(coords, argon.get_positions())
+
         # NOTE safe to change content of neigh
         create_neigh(coords, model_influence_dist, neigh)
-        error = kim_model.compute(compute_arguments)
+
+        try:
+            kim_model.compute(compute_arguments)
+        except RuntimeError:
+            raise kimpy.KimPyError('Calling "kim_model.compute" failed.')
+
         print('{:18.10e} {:18.10e} {:18.10e}'.format(
             energy[0], np.linalg.norm(forces), a))
 
-    # destory compute arguments
-    error = kim_model.compute_arguments_destroy(compute_arguments)
-    check_error(error, 'kim_model.compute_arguments_destroy')
+    try:
+        present, required = kim_model.is_routine_present(
+            kimpy.model_routine_name.WriteParameterizedModel)
+    except RuntimeError:
+        msg = 'Calling "kim_model.is_routine_present" failed.'
+        raise kimpy.KimPyError(msg)
 
-    out = kim_model.is_routine_present(
-        kimpy.model_routine_name.WriteParameterizedModel)
-    present, required, error = out
-    check_error(error, 'kim_model.is_routine_present')
     if present:
-        kim_model.write_parameterized_model('.', 'Morse_Ar')
+        try:
+            kim_model.write_parameterized_model('.', 'Morse_Ar')
+        except RuntimeError:
+            msg = 'Calling "kim_model.write_parameterized_model" failed.'
+            raise kimpy.KimPyError(msg)
+
         try:
             os.remove('Morse_Ar.params')
             os.remove('CMakeLists.txt')
             os.remove('kim.log')
         except:
             pass
-
-    # destory model
-    kimpy.model.destroy(kim_model)
-
 
 
 if __name__ == '__main__':

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -81,7 +81,8 @@ def test_main():
             kimpy.charge_unit.e,
             kimpy.temperature_unit.K,
             kimpy.time_unit.ps,
-            modelname)
+            modelname,
+        )
     except RuntimeError:
         raise kimpy.KimPyError('Calling "kimpy.model.create" failed.')
 
@@ -107,8 +108,9 @@ def test_main():
         raise kimpy.KimPyError(msg)
 
     # check compute arguments
-    num_compute_arguments = \
+    num_compute_arguments = (
         kimpy.compute_argument_name.get_number_of_compute_argument_names()
+    )
     print('Number of compute_arguments:', num_compute_arguments)
 
     for i in range(num_compute_arguments):
@@ -121,9 +123,7 @@ def test_main():
             raise kimpy.KimPyError(msg)
 
         try:
-            dtype = \
-                kimpy.compute_argument_name.get_compute_argument_data_type(
-                    name)
+            dtype = kimpy.compute_argument_name.get_compute_argument_data_type(name)
         except RuntimeError:
             msg = 'Calling "kimpy.compute_argument_name.'
             msg += 'get_compute_argument_data_type" for computeArgumentName = '
@@ -131,8 +131,7 @@ def test_main():
             raise kimpy.KimPyError(msg)
 
         try:
-            support_status = \
-                compute_arguments.get_argument_support_status(name)
+            support_status = compute_arguments.get_argument_support_status(name)
         except RuntimeError:
             msg = 'Calling "compute_arguments.get_argument_support_status" '
             msg += 'for computeArgumentName = {} failed.'.format(name)
@@ -151,24 +150,29 @@ def test_main():
 
         # can only handle energy and force as a required arg
         if support_status == kimpy.support_status.required:
-            if name not in (kimpy.compute_argument_name.partialEnergy,
-                            kimpy.compute_argument_name.partialForces):
+            if name not in (
+                kimpy.compute_argument_name.partialEnergy,
+                kimpy.compute_argument_name.partialForces,
+            ):
                 msg = 'Unsupported required ComputeArgumentName = '
                 msg += '{}'.format(name)
                 raise kimpy.KimPyError(msg)
 
         # must have energy and forces
-        if name in (kimpy.compute_argument_name.partialEnergy,
-                    kimpy.compute_argument_name.partialForces):
-            if support_status not in (kimpy.support_status.required,
-                                      kimpy.support_status.optional):
+        if name in (
+            kimpy.compute_argument_name.partialEnergy,
+            kimpy.compute_argument_name.partialForces,
+        ):
+            if support_status not in (
+                kimpy.support_status.required,
+                kimpy.support_status.optional,
+            ):
                 raise kimpy.KimPyError('Energy or forces not available')
 
     print()
 
     # check compute callbacks
-    num_callbacks = \
-        kimpy.compute_callback_name.get_number_of_compute_callback_names()
+    num_callbacks = kimpy.compute_callback_name.get_number_of_compute_callback_names()
 
     print('Number of callbacks:', num_callbacks)
 
@@ -182,8 +186,7 @@ def test_main():
             raise kimpy.KimPyError(msg)
 
         try:
-            support_status = \
-                compute_arguments.get_callback_support_status(name)
+            support_status = compute_arguments.get_callback_support_status(name)
         except RuntimeError:
             msg = 'Calling "compute_arguments.get_callback_support_status" '
             msg += 'for computeArgumentName = {} failed.'.format(name)
@@ -212,8 +215,7 @@ def test_main():
 
     for i in range(num_params):
         try:
-            dtype, extent, name, description = \
-                kim_model.get_parameter_metadata(i)
+            dtype, extent, name, description = kim_model.get_parameter_metadata(i)
         except RuntimeError:
             msg = 'Calling "kim_model.get_parameter_metadata" '
             msg += 'for parameterIndex = {} failed.'.format(i)
@@ -241,43 +243,48 @@ def test_main():
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.numberOfParticles, num_particles)
+            kimpy.compute_argument_name.numberOfParticles, num_particles
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.particleSpeciesCodes, species_code)
+            kimpy.compute_argument_name.particleSpeciesCodes, species_code
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.particleContributing,
-            particle_contributing)
+            kimpy.compute_argument_name.particleContributing, particle_contributing
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.coordinates, coords)
+            kimpy.compute_argument_name.coordinates, coords
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.partialEnergy, energy)
+            kimpy.compute_argument_name.partialEnergy, energy
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.partialForces, forces)
+            kimpy.compute_argument_name.partialForces, forces
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
@@ -288,7 +295,8 @@ def test_main():
     # register get neigh callback
     try:
         compute_arguments.set_callback(
-            kimpy.compute_callback_name.GetNeighborList, get_neigh, neigh)
+            kimpy.compute_callback_name.GetNeighborList, get_neigh, neigh
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_callback" failed.'
         raise kimpy.KimPyError(msg)
@@ -297,16 +305,19 @@ def test_main():
     model_influence_dist = kim_model.get_influence_distance()
     print('Model influence distance:', model_influence_dist)
 
-    model_cutoffs, padding_not_require_neigh_hints = \
-        kim_model.get_neighbor_list_cutoffs_and_hints()
+    (
+        model_cutoffs,
+        padding_not_require_neigh_hints,
+    ) = kim_model.get_neighbor_list_cutoffs_and_hints()
     print('Model cutoffs:', model_cutoffs)
     print('Model padding neighbors hints:', padding_not_require_neigh_hints)
     print()
 
     # species support and code
     try:
-        species_support, code = \
-            kim_model.get_species_support_and_code(kimpy.species_name.Ar)
+        species_support, code = kim_model.get_species_support_and_code(
+            kimpy.species_name.Ar
+        )
     except RuntimeError:
         msg = 'Calling "kim_model.get_species_support_and_code" failed.'
         raise kimpy.KimPyError(msg)
@@ -351,12 +362,14 @@ def test_main():
         except RuntimeError:
             raise kimpy.KimPyError('Calling "kim_model.compute" failed.')
 
-        print('{:18.10e} {:18.10e} {:18.10e}'.format(
-            energy[0], np.linalg.norm(forces), a))
+        print(
+            '{:18.10e} {:18.10e} {:18.10e}'.format(energy[0], np.linalg.norm(forces), a)
+        )
 
     try:
         present, required = kim_model.is_routine_present(
-            kimpy.model_routine_name.WriteParameterizedModel)
+            kimpy.model_routine_name.WriteParameterizedModel
+        )
     except RuntimeError:
         msg = 'Calling "kim_model.is_routine_present" failed.'
         raise kimpy.KimPyError(msg)

--- a/tests/test_model_neigh_library.py
+++ b/tests/test_model_neigh_library.py
@@ -308,7 +308,7 @@ def test_main():
         np.copyto(coords, argon.get_positions())
 
         try:
-            nl.build(neigh, coords, model_influence_dist, model_cutoffs, need_neigh)
+            neigh.build(coords, model_influence_dist, model_cutoffs, need_neigh)
         except RuntimeError:
             raise kimpy.KimPyError('Calling "neighlist.build" failed.')
 

--- a/tests/test_model_neigh_library.py
+++ b/tests/test_model_neigh_library.py
@@ -1,7 +1,6 @@
 import numpy as np
 import kimpy
 from kimpy import neighlist as nl
-from kimpy import check_error, report_error
 from ase.lattice.cubic import FaceCenteredCubic
 
 
@@ -24,23 +23,25 @@ def test_main():
     print()
 
     # create model
-    requestedUnitsAccepted, kim_model, error = kimpy.model.create(
-        kimpy.numbering.zeroBased,
-        kimpy.length_unit.A,
-        kimpy.energy_unit.eV,
-        kimpy.charge_unit.e,
-        kimpy.temperature_unit.K,
-        kimpy.time_unit.ps,
-        modelname,
-    )
-    check_error(error, 'kimpy.model.create')
+    try:
+        requestedUnitsAccepted, kim_model = kimpy.model.create(
+            kimpy.numbering.zeroBased,
+            kimpy.length_unit.A,
+            kimpy.energy_unit.eV,
+            kimpy.charge_unit.e,
+            kimpy.temperature_unit.K,
+            kimpy.time_unit.ps,
+            modelname)
+    except RuntimeError:
+        raise kimpy.KimPyError('Calling "kimpy.model.create" failed.')
 
     if not requestedUnitsAccepted:
-        report_error('requested units not accepted in kimpy.model.create')
+        msg = 'requested units not accepted in kimpy.model.create'
+        raise kimpy.KimPyError(msg)
 
     # units
     l_unit, e_unit, c_unit, te_unit, ti_unit = kim_model.get_units()
-    check_error(error, 'kim_model.get_units')
+
     print('Length unit is:', str(l_unit))
     print('Energy unit is:', str(e_unit))
     print('Charge unit is:', str(c_unit))
@@ -49,26 +50,43 @@ def test_main():
     print()
 
     # create compute arguments
-    compute_arguments, error = kim_model.compute_arguments_create()
-    check_error(error, 'kim_model.compute_arguments_create')
+    try:
+        compute_arguments = kim_model.compute_arguments_create()
+    except RuntimeError:
+        msg = 'Calling "kim_model.compute_arguments_create" failed.'
+        raise kimpy.KimPyError(msg)
 
     # check compute arguments
-    num_compute_arguments = (
+    num_compute_arguments = \
         kimpy.compute_argument_name.get_number_of_compute_argument_names()
-    )
     print('Number of compute_arguments:', num_compute_arguments)
 
     for i in range(num_compute_arguments):
-        name, error = kimpy.compute_argument_name.get_compute_argument_name(i)
-        check_error(error, 'kim_model.get_compute_argument_name')
+        try:
+            name = kimpy.compute_argument_name.get_compute_argument_name(i)
+        except RuntimeError:
+            msg = 'Calling "kimpy.compute_argument_name.'
+            msg += 'get_compute_argument_name" for index = '
+            msg += '{} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
 
-        dtype, error = \
-            kimpy.compute_argument_name.get_compute_argument_data_type(name)
-        check_error(error, 'kim_model.get_compute_argument_data_type')
+        try:
+            dtype = \
+                kimpy.compute_argument_name.get_compute_argument_data_type(
+                    name)
+        except RuntimeError:
+            msg = 'Calling "kimpy.compute_argument_name.'
+            msg += 'get_compute_argument_data_type" for computeArgumentName = '
+            msg += '{} failed.'.format(name)
+            raise kimpy.KimPyError(msg)
 
-        support_status, error = \
-            compute_arguments.get_argument_support_status(name)
-        check_error(error, 'compute_argument.get_argument_support_status')
+        try:
+            support_status = \
+                compute_arguments.get_argument_support_status(name)
+        except RuntimeError:
+            msg = 'Calling "compute_arguments.get_argument_support_status" '
+            msg += 'for computeArgumentName = {} failed.'.format(name)
+            raise kimpy.KimPyError(msg)
 
         n_space_1 = 21 - len(str(name))
         n_space_2 = 7 - len(str(dtype))
@@ -85,30 +103,44 @@ def test_main():
         if support_status == kimpy.support_status.required:
             if name not in (kimpy.compute_argument_name.partialEnergy,
                             kimpy.compute_argument_name.partialForces):
-                report_error('Unsupported required ComputeArgument')
+                msg = 'Unsupported required ComputeArgumentName = '
+                msg += '{}'.format(name)
+                raise kimpy.KimPyError(msg)
 
         # must have energy and forces
         if name in (kimpy.compute_argument_name.partialEnergy,
                     kimpy.compute_argument_name.partialForces):
             if support_status not in (kimpy.support_status.required,
                                       kimpy.support_status.optional):
-                report_error('Energy or forces not available')
+                raise kimpy.KimPyError('Energy or forces not available')
+
     print()
 
     # check compute callbacks
     num_callbacks = \
         kimpy.compute_callback_name.get_number_of_compute_callback_names()
+
     print('Number of callbacks:', num_callbacks)
 
     for i in range(num_callbacks):
-        name, error = kimpy.compute_callback_name.get_compute_callback_name(i)
-        check_error(error, 'kim_model.get_compute_callback_name')
+        try:
+            name = kimpy.compute_callback_name.get_compute_callback_name(i)
+        except RuntimeError:
+            msg = 'Calling "kimpy.compute_callback_name.'
+            msg += 'get_compute_callback_name" for index = '
+            msg += '{} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
 
-        support_status, error = \
-            compute_arguments.get_callback_support_status(name)
-        check_error(error, 'compute_argument.get_callback_support_status')
+        try:
+            support_status = \
+                compute_arguments.get_callback_support_status(name)
+        except RuntimeError:
+            msg = 'Calling "compute_arguments.get_callback_support_status" '
+            msg += 'for computeArgumentName = {} failed.'.format(name)
+            raise kimpy.KimPyError(msg)
 
         n_space = 18 - len(str(name))
+
         print(
             'Compute callback "{}"'.format(name)
             + ' ' * n_space
@@ -117,22 +149,32 @@ def test_main():
 
         # cannot handle any "required" callbacks
         if support_status == kimpy.support_status.required:
-            report_error('Unsupported required ComputeCallback')
+            raise kimpy.KimPyError('Unsupported required ComputeCallback')
+
     print()
 
     # parameter
     num_params = kim_model.get_number_of_parameters()
+
     print('Number of parameters:', num_params)
+
     print()
+
     for i in range(num_params):
-        out = kim_model.get_parameter_metadata(i)
-        dtype, extent, name, description, error = out
-        check_error(error, 'kim_model.get_parameter_metadata')
+        try:
+            dtype, extent, name, description = \
+                kim_model.get_parameter_metadata(i)
+        except RuntimeError:
+            msg = 'Calling "kim_model.get_parameter_metadata" '
+            msg += 'for parameterIndex = {} failed.'.format(i)
+            raise kimpy.KimPyError(msg)
+
         print('Parameter No.', i)
         print('    data type:', dtype)
         print('    extent:', extent)
         print('    name:', name)
         print('    description:', description)
+
     print()
 
     # register argument
@@ -147,60 +189,83 @@ def test_main():
     species_code = np.zeros(num_particles, dtype=np.intc)
     particle_contributing = np.zeros(num_particles, dtype=np.intc)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.numberOfParticles,
-        num_particles)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.numberOfParticles, num_particles)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.particleSpeciesCodes,
-        species_code)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.particleSpeciesCodes, species_code)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.particleContributing,
-        particle_contributing)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.particleContributing,
+            particle_contributing)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.coordinates,
-        coords)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.coordinates, coords)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.partialEnergy,
-        energy)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.partialEnergy, energy)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
-    error = compute_arguments.set_argument_pointer(
-        kimpy.compute_argument_name.partialForces,
-        forces)
-    check_error(error, 'kimpy.compute_argument.set_argument_pointer')
+    try:
+        compute_arguments.set_argument_pointer(
+            kimpy.compute_argument_name.partialForces, forces)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
     # create neighbor list
-    neigh = nl.initialize()
+    neigh = nl.create()
 
     # register get neigh callback
-
-    error = compute_arguments.set_callback_pointer(
-        kimpy.compute_callback_name.GetNeighborList,
-        nl.get_neigh_kim(), neigh)
-    check_error(error, 'kimpy.compute_argument.set_callback_pointer')
+    try:
+        compute_arguments.set_callback_pointer(
+            kimpy.compute_callback_name.GetNeighborList,
+            nl.get_neigh_kim(), neigh)
+    except RuntimeError:
+        msg = 'Calling "compute_arguments.set_callback_pointer" failed.'
+        raise kimpy.KimPyError(msg)
 
     # influence distance and cutoff of model
     model_influence_dist = kim_model.get_influence_distance()
-    out = kim_model.get_neighbor_list_cutoffs_and_hints()
-    model_cutoffs, padding_not_require_neigh_hints = out
     print('Model influence distance:', model_influence_dist)
+
+    model_cutoffs, padding_not_require_neigh_hints = \
+        kim_model.get_neighbor_list_cutoffs_and_hints()
     print('Model cutoffs:', model_cutoffs)
     print('Model padding neighbors hints:', padding_not_require_neigh_hints)
     print()
 
     # species support and code
-    species_support, code, error = \
-        kim_model.get_species_support_and_code(kimpy.species_name.Ar)
-    check_error(error or not species_support,
-                'kim_model.get_species_support_and_code')
+    try:
+        species_support, code = \
+            kim_model.get_species_support_and_code(kimpy.species_name.Ar)
+    except RuntimeError:
+        msg = 'Calling "kim_model.get_species_support_and_code" failed.'
+        raise kimpy.KimPyError(msg)
+
+    if not species_support:
+        msg = 'Ar species is not supported by this model.'
+        raise kimpy.KimPyError(msg)
+
     print('Species Ar is supported and its code is:', code)
     print()
 
@@ -228,29 +293,28 @@ def test_main():
 
     for a in all_alat:
         argon = create_fcc_argon(a)
+
         # NOTE cannot change coords address
         np.copyto(coords, argon.get_positions())
-        error = nl.build(neigh,
-                         coords,
-                         model_influence_dist,
-                         model_cutoffs,
-                         need_neigh)
-        check_error(error, 'nl.build')
-        error = kim_model.compute(compute_arguments)
+
+        try:
+            nl.build(neigh,
+                     coords,
+                     model_influence_dist,
+                     model_cutoffs,
+                     need_neigh)
+        except RuntimeError:
+            raise kimpy.KimPyError('Calling "neighlist.build" failed.')
+
+        try:
+            kim_model.compute(compute_arguments)
+        except RuntimeError:
+            raise kimpy.KimPyError('Calling "kim_model.compute" failed.')
+
         print(
             '{:18.10e} {:18.10e} {:18.10e}'.format(
                 energy[0], np.linalg.norm(forces), a)
         )
-
-    # destory neighbor list
-    nl.clean(neigh)
-
-    # destory compute arguments
-    error = kim_model.compute_arguments_destroy(compute_arguments)
-    check_error(error, 'kim_model.compute_arguments_destroy')
-
-    # destory model
-    kimpy.model.destroy(kim_model)
 
 
 if __name__ == '__main__':

--- a/tests/test_model_neigh_library.py
+++ b/tests/test_model_neigh_library.py
@@ -31,7 +31,8 @@ def test_main():
             kimpy.charge_unit.e,
             kimpy.temperature_unit.K,
             kimpy.time_unit.ps,
-            modelname)
+            modelname,
+        )
     except RuntimeError:
         raise kimpy.KimPyError('Calling "kimpy.model.create" failed.')
 
@@ -57,8 +58,9 @@ def test_main():
         raise kimpy.KimPyError(msg)
 
     # check compute arguments
-    num_compute_arguments = \
+    num_compute_arguments = (
         kimpy.compute_argument_name.get_number_of_compute_argument_names()
+    )
     print('Number of compute_arguments:', num_compute_arguments)
 
     for i in range(num_compute_arguments):
@@ -71,9 +73,7 @@ def test_main():
             raise kimpy.KimPyError(msg)
 
         try:
-            dtype = \
-                kimpy.compute_argument_name.get_compute_argument_data_type(
-                    name)
+            dtype = kimpy.compute_argument_name.get_compute_argument_data_type(name)
         except RuntimeError:
             msg = 'Calling "kimpy.compute_argument_name.'
             msg += 'get_compute_argument_data_type" for computeArgumentName = '
@@ -81,8 +81,7 @@ def test_main():
             raise kimpy.KimPyError(msg)
 
         try:
-            support_status = \
-                compute_arguments.get_argument_support_status(name)
+            support_status = compute_arguments.get_argument_support_status(name)
         except RuntimeError:
             msg = 'Calling "compute_arguments.get_argument_support_status" '
             msg += 'for computeArgumentName = {} failed.'.format(name)
@@ -101,24 +100,29 @@ def test_main():
 
         # can only handle energy and force as a required arg
         if support_status == kimpy.support_status.required:
-            if name not in (kimpy.compute_argument_name.partialEnergy,
-                            kimpy.compute_argument_name.partialForces):
+            if name not in (
+                kimpy.compute_argument_name.partialEnergy,
+                kimpy.compute_argument_name.partialForces,
+            ):
                 msg = 'Unsupported required ComputeArgumentName = '
                 msg += '{}'.format(name)
                 raise kimpy.KimPyError(msg)
 
         # must have energy and forces
-        if name in (kimpy.compute_argument_name.partialEnergy,
-                    kimpy.compute_argument_name.partialForces):
-            if support_status not in (kimpy.support_status.required,
-                                      kimpy.support_status.optional):
+        if name in (
+            kimpy.compute_argument_name.partialEnergy,
+            kimpy.compute_argument_name.partialForces,
+        ):
+            if support_status not in (
+                kimpy.support_status.required,
+                kimpy.support_status.optional,
+            ):
                 raise kimpy.KimPyError('Energy or forces not available')
 
     print()
 
     # check compute callbacks
-    num_callbacks = \
-        kimpy.compute_callback_name.get_number_of_compute_callback_names()
+    num_callbacks = kimpy.compute_callback_name.get_number_of_compute_callback_names()
 
     print('Number of callbacks:', num_callbacks)
 
@@ -132,8 +136,7 @@ def test_main():
             raise kimpy.KimPyError(msg)
 
         try:
-            support_status = \
-                compute_arguments.get_callback_support_status(name)
+            support_status = compute_arguments.get_callback_support_status(name)
         except RuntimeError:
             msg = 'Calling "compute_arguments.get_callback_support_status" '
             msg += 'for computeArgumentName = {} failed.'.format(name)
@@ -162,8 +165,7 @@ def test_main():
 
     for i in range(num_params):
         try:
-            dtype, extent, name, description = \
-                kim_model.get_parameter_metadata(i)
+            dtype, extent, name, description = kim_model.get_parameter_metadata(i)
         except RuntimeError:
             msg = 'Calling "kim_model.get_parameter_metadata" '
             msg += 'for parameterIndex = {} failed.'.format(i)
@@ -191,43 +193,48 @@ def test_main():
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.numberOfParticles, num_particles)
+            kimpy.compute_argument_name.numberOfParticles, num_particles
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.particleSpeciesCodes, species_code)
+            kimpy.compute_argument_name.particleSpeciesCodes, species_code
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.particleContributing,
-            particle_contributing)
+            kimpy.compute_argument_name.particleContributing, particle_contributing
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.coordinates, coords)
+            kimpy.compute_argument_name.coordinates, coords
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.partialEnergy, energy)
+            kimpy.compute_argument_name.partialEnergy, energy
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
 
     try:
         compute_arguments.set_argument_pointer(
-            kimpy.compute_argument_name.partialForces, forces)
+            kimpy.compute_argument_name.partialForces, forces
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_argument_pointer" failed.'
         raise kimpy.KimPyError(msg)
@@ -238,8 +245,8 @@ def test_main():
     # register get neigh callback
     try:
         compute_arguments.set_callback_pointer(
-            kimpy.compute_callback_name.GetNeighborList,
-            nl.get_neigh_kim(), neigh)
+            kimpy.compute_callback_name.GetNeighborList, nl.get_neigh_kim(), neigh
+        )
     except RuntimeError:
         msg = 'Calling "compute_arguments.set_callback_pointer" failed.'
         raise kimpy.KimPyError(msg)
@@ -248,16 +255,19 @@ def test_main():
     model_influence_dist = kim_model.get_influence_distance()
     print('Model influence distance:', model_influence_dist)
 
-    model_cutoffs, padding_not_require_neigh_hints = \
-        kim_model.get_neighbor_list_cutoffs_and_hints()
+    (
+        model_cutoffs,
+        padding_not_require_neigh_hints,
+    ) = kim_model.get_neighbor_list_cutoffs_and_hints()
     print('Model cutoffs:', model_cutoffs)
     print('Model padding neighbors hints:', padding_not_require_neigh_hints)
     print()
 
     # species support and code
     try:
-        species_support, code = \
-            kim_model.get_species_support_and_code(kimpy.species_name.Ar)
+        species_support, code = kim_model.get_species_support_and_code(
+            kimpy.species_name.Ar
+        )
     except RuntimeError:
         msg = 'Calling "kim_model.get_species_support_and_code" failed.'
         raise kimpy.KimPyError(msg)
@@ -298,11 +308,7 @@ def test_main():
         np.copyto(coords, argon.get_positions())
 
         try:
-            nl.build(neigh,
-                     coords,
-                     model_influence_dist,
-                     model_cutoffs,
-                     need_neigh)
+            nl.build(neigh, coords, model_influence_dist, model_cutoffs, need_neigh)
         except RuntimeError:
             raise kimpy.KimPyError('Calling "neighlist.build" failed.')
 
@@ -312,8 +318,7 @@ def test_main():
             raise kimpy.KimPyError('Calling "kim_model.compute" failed.')
 
         print(
-            '{:18.10e} {:18.10e} {:18.10e}'.format(
-                energy[0], np.linalg.norm(forces), a)
+            '{:18.10e} {:18.10e} {:18.10e}'.format(energy[0], np.linalg.norm(forces), a)
         )
 
 

--- a/tests/test_sem_ver.py
+++ b/tests/test_sem_ver.py
@@ -1,18 +1,26 @@
 import kimpy
-from kimpy import check_error
 
 
 def test_main():
-
     version = kimpy.sem_ver.get_sem_ver()
-    ls_less_than, error = kimpy.sem_ver.is_less_than('2.0.1', '2.1.0')
-    check_error(error, 'kimpy.sem_ver.is_less_than')
-    out = kimpy.sem_ver.parse_sem_ver(version)
-    version_related = out[:-1]
+
+    try:
+        ls_less_than = kimpy.sem_ver.is_less_than('2.0.1', '2.1.0')
+    except RuntimeError:
+        msg = 'Calling "kimpy.sem_ver.is_less_than" failed.'
+        raise kimpy.KimPyError(msg)
+
+    assert ls_less_than == 1
+
+    try:
+        version_related = kimpy.sem_ver.parse_sem_ver(version)
+    except RuntimeError:
+        msg = 'Calling "kimpy.sem_ver.parse_sem_ver" failed.'
+        raise kimpy.KimPyError(msg)
+
     version_rebuilt_1 = '{}.{}.{}{}+{}'.format(*version_related)
     version_rebuilt_2 = '{}.{}.{}-{}+{}'.format(*version_related)
 
-    assert ls_less_than == 1
     assert version in (version_rebuilt_1, version_rebuilt_2)
 
 

--- a/tests/test_sem_ver.py
+++ b/tests/test_sem_ver.py
@@ -5,12 +5,12 @@ def test_main():
     version = kimpy.sem_ver.get_sem_ver()
 
     try:
-        ls_less_than = kimpy.sem_ver.is_less_than('2.0.1', '2.1.0')
+        is_less_than = kimpy.sem_ver.is_less_than('2.0.1', '2.1.0')
     except RuntimeError:
         msg = 'Calling "kimpy.sem_ver.is_less_than" failed.'
         raise kimpy.KimPyError(msg)
 
-    assert ls_less_than == 1
+    assert is_less_than == 1
 
     try:
         version_related = kimpy.sem_ver.parse_sem_ver(version)

--- a/utils/format_sources.py
+++ b/utils/format_sources.py
@@ -54,7 +54,6 @@ def format_cpp_code(path, exclude=['KIM_ComputeArguments_bind.cpp']):
 
 
 if __name__ == '__main__':
-    kimpy_root_dir = \
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+    kimpy_root_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
     format_py_code(kimpy_root_dir)
     format_cpp_code(kimpy_root_dir)

--- a/utils/format_sources.py
+++ b/utils/format_sources.py
@@ -54,5 +54,7 @@ def format_cpp_code(path, exclude=['KIM_ComputeArguments_bind.cpp']):
 
 
 if __name__ == '__main__':
-    format_py_code('../')
-    format_cpp_code('../')
+    kimpy_root_dir = \
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+    format_py_code(kimpy_root_dir)
+    format_cpp_code(kimpy_root_dir)

--- a/utils/remove_generated_files.py
+++ b/utils/remove_generated_files.py
@@ -23,11 +23,7 @@ def remove_generated_files(path):
     ]
 
     dir_list_files = {
-        'examples': [
-            "error.py",
-            "example_collections.py",
-            "example_simulator_model.py"
-        ],
+        'examples': ["error.py", "example_collections.py", "example_simulator_model.py"],
         'kimpy': [
             "KIM_Collections_bind.cpp",
             "KIM_ComputeArgumentName_bind.cpp",
@@ -41,7 +37,7 @@ def remove_generated_files(path):
             "err.py",
             "neighlist",
             "sim_buffer.h",
-            "py_kim_wrapper.h"
+            "py_kim_wrapper.h",
         ],
         'scripts': [
             "KIM_FieldName_bind.cpp-template",
@@ -72,7 +68,7 @@ def remove_generated_files(path):
         join('tests', 'neighlist'): [
             'cpp_example',
             'test_graphite.py',
-        ]
+        ],
     }
 
     for dir_name in dir_list:

--- a/utils/remove_generated_files.py
+++ b/utils/remove_generated_files.py
@@ -41,6 +41,7 @@ def remove_generated_files(path):
             "err.py",
             "neighlist",
             "sim_buffer.h",
+            "py_kim_wrapper.h"
         ],
         'scripts': [
             "KIM_FieldName_bind.cpp-template",


### PR DESCRIPTION
### Summary

This PR removes the manual memory management (where `kimpy` users had to explicitly create and destroy objects)

- Removes the manual memory management. This update addresses the issue https://github.com/openkim/kimpy/issues/8
  
- Update the implementation. Now there is no `error` message returned back from the `KIM-API` to the users. In case of an error, it throws a `RuntimeError` exception with a message explaining the reason.
  For example, you can create a `collections` object as,

  ```py
  collections = kimpy.collections.create()  # collections = kimpy.collections.Collections()
  ```

  or,

  ```py
  try:
    collections = kimpy.collections.create()
  except RuntimeError:
    msg = 'Calling "kimpy.collections.create" failed.'
    raise kimpy.KimPyError(msg)
  ```

- Update the returned values and input arguments naming to lower case.
- Add document to all methods
- Update the NeighList bindings.
   Now to use the neighlist, 
   ```py
   # create a NeighList object 
   neigh = neighlist.create()    # or neigh = neighlist.NeighList()

   # build the neighbor list
   neigh.build(coords, influence_dist, cutoffs, need_neigh)
   
   # get number of neighbors and neighbors of the requested particle
   number_of_neighbors, neighbors_of_particle = neigh.get_neigh(cutoffs, neigh_list_index, particle)
   ```

### Related Issue(s)

https://github.com/openkim/kimpy/issues/8

### Backward Compatibility

This PR is not backward compatible

### Author(s)

Yaser Afshar (UMN)